### PR TITLE
Add default cycling speed setting for estimated mileage

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,29 @@
+# Plan: Default Cycling Speed Setting & Auto-Mileage Calculation
+
+## Overview
+Add a configurable "Default Cycling Speed" setting (17/18/19 mph) that automatically calculates mileage for cycling workouts that have no miles recorded from the source. Formula: `miles = minutes * (speed / 60)`.
+
+## Changes
+
+### 1. `src/context/SettingsContext.tsx`
+- Add `defaultCyclingSpeed: number` to the `Settings` interface (default: `18`)
+
+### 2. `src/utils/workoutMultipliers.ts`
+- Add a new exported function `applyDefaultMileage(sessions, defaultCyclingSpeed)` that:
+  - For any session where `activity` is "Cycling" and `miles` is falsy (null/undefined/0), calculates `miles = minutes * (defaultCyclingSpeed / 60)`
+  - Sets a flag `estimatedMiles: true` so the UI can distinguish calculated vs. recorded mileage
+  - Non-cycling sessions and sessions with existing mileage pass through unchanged
+
+### 3. `src/components/WorkoutDashboard.tsx`
+- In the `enhancedSessions` pipeline, call `applyDefaultMileage()` **before** `applyWorkoutMultipliers()` so Cannondale outdoor cycling also gets default mileage filled in before the multiplier
+- Wire `settings.defaultCyclingSpeed` through
+- Add a "Default Cycling Speed" section to the Settings modal (between Outdoor Bonus and Units), with 17/18/19 mph toggle buttons matching the existing button style
+
+### 4. `src/components/WorkoutTable.tsx`
+- Add the `estimatedMiles` field to the interface
+- When a session has `estimatedMiles: true`, show a small indicator (e.g. italic or a calc icon) so the user can see the mileage was estimated
+
+## What Won't Change
+- Database schema — no new columns; this is purely a client-side display calculation
+- API routes — mileage estimation happens at render time
+- WorkoutSummary / MonthlySummary — they already read `miles` / `adjustedMiles` from sessions, so they'll automatically pick up the calculated values

--- a/src/components/WorkoutDashboard.tsx
+++ b/src/components/WorkoutDashboard.tsx
@@ -11,7 +11,7 @@ import { WorkoutSummary } from './WorkoutSummary'
 import { ThemeToggle } from './ThemeToggle'
 import { AuthHeader } from './AuthHeader'
 import { Plus, X, Target, Calendar, ArrowLeftRight, Settings, RefreshCw, Upload, Check } from 'lucide-react'
-import { applyWorkoutMultipliers } from '../utils/workoutMultipliers'
+import { applyDefaultMileage, applyWorkoutMultipliers } from '../utils/workoutMultipliers'
 import { useSettings } from '../context/SettingsContext'
 
 export interface WorkoutSession {
@@ -23,6 +23,7 @@ export interface WorkoutSession {
   miles?: number
   adjustedMiles?: number // Miles with multiplier applied (for Cannondale)
   adjustedMinutes?: number // Minutes with multiplier applied (for Cannondale)
+  estimatedMiles?: boolean // True when miles were calculated from default cycling speed
   weightLifted?: number
   notes?: string
 }
@@ -257,10 +258,11 @@ export function WorkoutDashboard() {
     return session.date.getFullYear() === currentYear
   })
 
-  // Apply workout multipliers for goal calculations (e.g., Cannondale outdoor bonus)
+  // Apply default mileage for cycling workouts without recorded miles, then outdoor multipliers
   const enhancedSessions = useMemo(() => {
-    return applyWorkoutMultipliers(currentYearSessions, settings.outdoorMultiplier)
-  }, [currentYearSessions, settings.outdoorMultiplier])
+    const withMileage = applyDefaultMileage(currentYearSessions, settings.defaultCyclingSpeed)
+    return applyWorkoutMultipliers(withMileage, settings.outdoorMultiplier)
+  }, [currentYearSessions, settings.defaultCyclingSpeed, settings.outdoorMultiplier])
 
   // Set current date/year on client side only
   useEffect(() => {
@@ -1039,6 +1041,29 @@ export function WorkoutDashboard() {
                 >
                   <X className="w-6 h-6" />
                 </button>
+              </div>
+
+              {/* Default Cycling Speed */}
+              <div className="mb-6">
+                <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Default Cycling Speed</h3>
+                <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                  Used to estimate mileage when not recorded by the source.
+                </p>
+                <div className="flex gap-2">
+                  {[17, 18, 19].map((speed) => (
+                    <button
+                      key={speed}
+                      onClick={() => updateSettings({ defaultCyclingSpeed: speed })}
+                      className={`px-3 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                        settings.defaultCyclingSpeed === speed
+                          ? 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-600 dark:text-indigo-400 ring-2 ring-indigo-500'
+                          : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700'
+                      }`}
+                    >
+                      {speed} mph
+                    </button>
+                  ))}
+                </div>
               </div>
 
               {/* Outdoor Bonus */}

--- a/src/components/WorkoutTable.tsx
+++ b/src/components/WorkoutTable.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from 'react'
 import { format } from 'date-fns'
 import { WorkoutSession } from './WorkoutDashboard'
-import { Edit2, Trash2, Bike } from 'lucide-react'
+import { Edit2, Trash2, Bike, Calculator } from 'lucide-react'
 import { formatNumber } from '../utils/numberFormat'
 
 interface WorkoutTableProps {
@@ -116,6 +116,13 @@ export function WorkoutTable({ sessions, onEdit, onDelete }: WorkoutTableProps) 
                         <Bike className="w-3 h-3 inline-block" />
                       </span>
                       <span className="text-gray-700 dark:text-gray-300">{formatNumber(session.adjustedMiles)}</span>
+                    </>
+                  ) : session.estimatedMiles ? (
+                    <>
+                      <span title="Estimated from default cycling speed" className="text-amber-500 dark:text-amber-400">
+                        <Calculator className="w-3 h-3 inline-block" />
+                      </span>
+                      <span className="text-gray-700 dark:text-gray-300 italic">{session.miles ? formatNumber(session.miles) : '—'}</span>
                     </>
                   ) : (
                     <span className="text-gray-700 dark:text-gray-300">

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -9,6 +9,7 @@ export interface Settings {
   defaultActivity: string
   units: Units
   outdoorMultiplier: number
+  defaultCyclingSpeed: number
 }
 
 const defaultSettings: Settings = {
@@ -16,6 +17,7 @@ const defaultSettings: Settings = {
   defaultActivity: 'Cycling',
   units: 'imperial',
   outdoorMultiplier: 1.5,
+  defaultCyclingSpeed: 18,
 }
 
 interface SettingsContextType {

--- a/src/utils/workoutMultipliers.ts
+++ b/src/utils/workoutMultipliers.ts
@@ -1,6 +1,38 @@
 import { WorkoutSession } from '../components/WorkoutDashboard'
 
 /**
+ * Calculate default mileage for cycling workouts that have no recorded miles.
+ * Uses the formula: miles = minutes * (defaultSpeed / 60)
+ *
+ * @param sessions Array of workout sessions
+ * @param defaultSpeed Default cycling speed in mph (e.g. 17, 18, 19)
+ * @returns Array of workout sessions with estimated mileage applied where needed
+ */
+export function applyDefaultMileage(
+  sessions: WorkoutSession[],
+  defaultSpeed: number = 18,
+): WorkoutSession[] {
+  return sessions.map(session => {
+    const isCycling = session.activity.toLowerCase() === 'cycling'
+    const hasMiles = session.miles !== undefined && session.miles !== null && session.miles > 0
+
+    if (isCycling && !hasMiles && session.minutes > 0) {
+      const estimatedMiles = parseFloat((session.minutes * (defaultSpeed / 60)).toFixed(2))
+      return {
+        ...session,
+        miles: estimatedMiles,
+        estimatedMiles: true,
+      }
+    }
+
+    return {
+      ...session,
+      estimatedMiles: false,
+    }
+  })
+}
+
+/**
  * Apply outdoor multiplier to Cannondale rides (miles and minutes).
  *
  * @param sessions Array of workout sessions


### PR DESCRIPTION
## What
Adds a configurable Default Cycling Speed setting (17/18/19 mph) that automatically estimates mileage for cycling workouts when the source doesn't provide it.

## How it works
- **Formula**: `miles = minutes × (speed / 60)`
- Applied client-side before the outdoor multiplier, so Cannondale rides without mileage also get the estimate before the bonus stacks
- Estimated values shown in the workout table with a calculator icon and italic text

## Changes
- `SettingsContext` — new `defaultCyclingSpeed` field (default 18 mph)
- `workoutMultipliers.ts` — new `applyDefaultMileage()` function
- `WorkoutDashboard` — wired into the pipeline, new Settings UI section
- `WorkoutTable` — visual indicator for estimated mileage

No database or API changes.