### PR TITLE
Phase 5: Accessibility

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -68,6 +68,7 @@ export function DashboardHeader({
                 disabled={importing}
                 className="bg-gray-700 dark:bg-gray-500 hover:bg-gray-800 dark:hover:bg-gray-400 disabled:opacity-50 text-white dark:text-gray-900 p-1.5 rounded-lg transition-colors shadow-sm"
                 title="Import Tonal screenshot (fallback)"
+                aria-label="Import Tonal screenshot"
               >
                 <Upload className={`w-3.5 h-3.5 ${importing ? 'animate-pulse' : ''}`} />
                 {importing && importProgress && <span className="text-[10px]">{importProgress}</span>}
@@ -76,6 +77,7 @@ export function DashboardHeader({
                 onClick={onSettingsClick}
                 className="p-1.5 rounded-lg bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
                 title="Settings"
+                aria-label="Settings"
               >
                 <Settings className="w-4 h-4 text-gray-500" />
               </button>
@@ -189,6 +191,7 @@ export function DashboardHeader({
               onClick={onSettingsClick}
               className="p-2 rounded-lg bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
               title="Settings"
+              aria-label="Settings"
             >
               <Settings className="w-4 h-4 text-gray-500" />
             </button>

--- a/src/components/GoalModal.tsx
+++ b/src/components/GoalModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { Goal } from '@/types/workout'
 import { X } from 'lucide-react'
 import { createGoal } from '../utils/goalCalculations'
@@ -20,6 +20,48 @@ export function GoalModal({ isOpen, onClose, onSubmit, existingGoal }: GoalModal
     minutesPerSession: existingGoal?.minutesPerSession || 45,
     weeklySessionsTarget: existingGoal?.weeklySessionsTarget || 5
   })
+
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Focus trap: focus the panel on open, wrap Tab at boundaries
+  useEffect(() => {
+    if (!isOpen || !panelRef.current) return
+
+    panelRef.current.focus()
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !panelRef.current) return
+
+      const focusableElements = panelRef.current.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )
+      if (focusableElements.length === 0) return
+
+      const first = focusableElements[0]
+      const last = focusableElements[focusableElements.length - 1]
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault()
+          last.focus()
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen])
+
+  const handleEscapeKey = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      onClose()
+    }
+  }, [onClose])
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -46,23 +88,31 @@ export function GoalModal({ isOpen, onClose, onSubmit, existingGoal }: GoalModal
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-6 w-full max-w-md mx-4">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="goal-modal-title"
+      onKeyDown={handleEscapeKey}
+      tabIndex={-1}
+    >
+      <div ref={panelRef} className="bg-white rounded-lg p-6 w-full max-w-md mx-4" tabIndex={-1}>
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-xl font-bold text-gray-900">
+          <h2 id="goal-modal-title" className="text-xl font-bold text-gray-900">
             {existingGoal ? 'Edit Goal' : 'Create New Goal'}
           </h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600" aria-label="Close goal modal">
             <X className="w-6 h-6" />
           </button>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="goal-name" className="block text-sm font-medium text-gray-700 mb-1">
               Goal Name
             </label>
             <input
+              id="goal-name"
               type="text"
               value={formData.name}
               onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
@@ -73,10 +123,11 @@ export function GoalModal({ isOpen, onClose, onSubmit, existingGoal }: GoalModal
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="goal-year" className="block text-sm font-medium text-gray-700 mb-1">
               Year
             </label>
             <input
+              id="goal-year"
               type="number"
               value={formData.year}
               onChange={(e) => setFormData(prev => ({ ...prev, year: parseInt(e.target.value) }))}
@@ -88,10 +139,11 @@ export function GoalModal({ isOpen, onClose, onSubmit, existingGoal }: GoalModal
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="goal-weight-target" className="block text-sm font-medium text-gray-700 mb-1">
               Annual Weight Target (lbs)
             </label>
             <input
+              id="goal-weight-target"
               type="text"
               value={formData.annualWeightTarget.toLocaleString()}
               onChange={(e) => {
@@ -105,10 +157,11 @@ export function GoalModal({ isOpen, onClose, onSubmit, existingGoal }: GoalModal
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="goal-minutes-per-session" className="block text-sm font-medium text-gray-700 mb-1">
               Minutes per Session
             </label>
             <input
+              id="goal-minutes-per-session"
               type="number"
               value={formData.minutesPerSession}
               onChange={(e) => setFormData(prev => ({ ...prev, minutesPerSession: parseInt(e.target.value) }))}
@@ -119,10 +172,11 @@ export function GoalModal({ isOpen, onClose, onSubmit, existingGoal }: GoalModal
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="goal-sessions-per-week" className="block text-sm font-medium text-gray-700 mb-1">
               Sessions per Week
             </label>
             <input
+              id="goal-sessions-per-week"
               type="number"
               value={formData.weeklySessionsTarget}
               onChange={(e) => setFormData(prev => ({ ...prev, weeklySessionsTarget: parseInt(e.target.value) }))}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import React, { useRef, useEffect, useCallback } from 'react'
 import { X } from 'lucide-react'
 import { useSettings } from '../context/SettingsContext'
 
@@ -11,16 +11,76 @@ interface SettingsModalProps {
 
 export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const { settings, updateSettings } = useSettings()
+  const backdropRef = useRef<HTMLDivElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Auto-focus the dialog when it opens
+  useEffect(() => {
+    if (isOpen && backdropRef.current) {
+      backdropRef.current.focus()
+    }
+  }, [isOpen])
+
+  // Focus trap: keep Tab/Shift+Tab within the modal
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleFocusTrap = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !panelRef.current) return
+
+      const focusableElements = panelRef.current.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )
+      if (focusableElements.length === 0) return
+
+      const firstElement = focusableElements[0]
+      const lastElement = focusableElements[focusableElements.length - 1]
+
+      if (e.shiftKey) {
+        if (document.activeElement === firstElement) {
+          e.preventDefault()
+          lastElement.focus()
+        }
+      } else {
+        if (document.activeElement === lastElement) {
+          e.preventDefault()
+          firstElement.focus()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleFocusTrap)
+    return () => document.removeEventListener('keydown', handleFocusTrap)
+  }, [isOpen])
+
+  // Escape key handler
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape') {
+        onClose()
+      }
+    },
+    [onClose]
+  )
 
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white dark:bg-gray-900 rounded-lg p-6 max-w-md w-full max-h-[90vh] overflow-y-auto">
+    <div
+      ref={backdropRef}
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="settings-modal-title"
+      onKeyDown={handleKeyDown}
+      tabIndex={-1}
+    >
+      <div ref={panelRef} className="bg-white dark:bg-gray-900 rounded-lg p-6 max-w-md w-full max-h-[90vh] overflow-y-auto">
         <div className="flex justify-between items-center mb-6">
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white">Settings</h2>
+          <h2 id="settings-modal-title" className="text-xl font-bold text-gray-900 dark:text-white">Settings</h2>
           <button
             onClick={onClose}
+            aria-label="Close settings"
             className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
           >
             <X className="w-6 h-6" />
@@ -33,10 +93,12 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
           <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
             Used to estimate mileage when not recorded by the source.
           </p>
-          <div className="flex gap-2">
+          <div className="flex gap-2" role="radiogroup" aria-label="Default Cycling Speed">
             {[17, 18, 19].map((speed) => (
               <button
                 key={speed}
+                role="radio"
+                aria-checked={settings.defaultCyclingSpeed === speed}
                 onClick={() => updateSettings({ defaultCyclingSpeed: speed })}
                 className={`px-3 py-2 rounded-lg text-sm font-semibold transition-colors ${
                   settings.defaultCyclingSpeed === speed
@@ -56,10 +118,12 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
           <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
             Cannondale outdoor rides get bonus credit for minutes and miles.
           </p>
-          <div className="flex gap-2">
+          <div className="flex gap-2" role="radiogroup" aria-label="Outdoor Bonus">
             {[1, 1.25, 1.5, 1.75, 2].map((m) => (
               <button
                 key={m}
+                role="radio"
+                aria-checked={settings.outdoorMultiplier === m}
                 onClick={() => updateSettings({ outdoorMultiplier: m })}
                 className={`px-3 py-2 rounded-lg text-sm font-semibold transition-colors ${
                   settings.outdoorMultiplier === m
@@ -76,8 +140,10 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
         {/* Units */}
         <div className="mb-6">
           <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Units</h3>
-          <div className="flex gap-2">
+          <div className="flex gap-2" role="radiogroup" aria-label="Units">
             <button
+              role="radio"
+              aria-checked={settings.units === 'imperial'}
               onClick={() => updateSettings({ units: 'imperial' })}
               className={`flex-1 px-3 py-2 rounded-lg text-sm font-semibold text-center transition-colors ${
                 settings.units === 'imperial'
@@ -88,6 +154,8 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
               🇺🇸 Imperial (mi, lbs)
             </button>
             <button
+              role="radio"
+              aria-checked={settings.units === 'metric'}
               onClick={() => updateSettings({ units: 'metric' })}
               className={`flex-1 px-3 py-2 rounded-lg text-sm font-semibold text-center transition-colors ${
                 settings.units === 'metric'
@@ -103,10 +171,12 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
         {/* Workout Defaults */}
         <div className="mb-6">
           <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Default Source</h3>
-          <div className="flex gap-2 flex-wrap">
+          <div className="flex gap-2 flex-wrap" role="radiogroup" aria-label="Default Source">
             {['Peloton', 'Tonal', 'Cannondale', 'Other'].map((s) => (
               <button
                 key={s}
+                role="radio"
+                aria-checked={settings.defaultSource === s}
                 onClick={() => updateSettings({ defaultSource: s })}
                 className={`px-3 py-2 rounded-lg text-sm font-semibold transition-colors ${
                   settings.defaultSource === s
@@ -122,10 +192,12 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
 
         <div className="mb-2">
           <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Default Activity</h3>
-          <div className="flex gap-2 flex-wrap">
+          <div className="flex gap-2 flex-wrap" role="radiogroup" aria-label="Default Activity">
             {['Cycling', 'Weight Lifting', 'Running', 'Walking', 'Yoga', 'Other'].map((a) => (
               <button
                 key={a}
+                role="radio"
+                aria-checked={settings.defaultActivity === a}
                 onClick={() => updateSettings({ defaultActivity: a })}
                 className={`px-3 py-2 rounded-lg text-sm font-semibold transition-colors ${
                   settings.defaultActivity === a

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -40,7 +40,7 @@ export function ThemeToggle() {
 
   if (!mounted) {
     return (
-      <button className="p-2 rounded-lg bg-gray-100 dark:bg-gray-800">
+      <button className="p-2 rounded-lg bg-gray-100 dark:bg-gray-800" aria-label="Toggle theme">
         <Monitor className="w-5 h-5" />
       </button>
     )
@@ -51,6 +51,7 @@ export function ThemeToggle() {
       onClick={handleThemeChange}
       className="p-2 rounded-lg bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
       title={`Current theme: ${theme}`}
+      aria-label={`Toggle theme, current: ${theme}`}
     >
       {theme === 'light' && <Sun className="w-5 h-5 text-yellow-500" />}
       {theme === 'dark' && <Moon className="w-5 h-5 text-blue-500" />}

--- a/src/components/WorkoutDashboard.tsx
+++ b/src/components/WorkoutDashboard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useMemo, useCallback } from 'react'
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { WorkoutTable } from './WorkoutTable'
 import { WorkoutForm } from './WorkoutForm'
 import { MonthlySummary } from './MonthlySummary'
@@ -39,7 +39,8 @@ export function WorkoutDashboard() {
   const [syncSuccess, setSyncSuccess] = useState<string | null>(null)
   const [importing, setImporting] = useState(false)
   const [importProgress, setImportProgress] = useState<string | null>(null)
-  const tonalFileRef = React.useRef<HTMLInputElement>(null)
+  const tonalFileRef = useRef<HTMLInputElement>(null)
+  const addWorkoutPanelRef = useRef<HTMLDivElement>(null)
 
   // Filter sessions by current year
   const currentYearSessions = useMemo(() => 
@@ -249,7 +250,7 @@ export function WorkoutDashboard() {
       setSessions(prev => prev.filter(s => s.id !== id))
     } catch (error) {
       console.error('Failed to delete workout:', error)
-      alert('Failed to delete workout. Please try again.')
+      setSyncError('Failed to delete workout. Please try again.')
     }
   }, [])
 
@@ -491,6 +492,33 @@ export function WorkoutDashboard() {
     }
   }
 
+  useEffect(() => {
+    if (!showAddWorkout) return
+    const panel = addWorkoutPanelRef.current
+    if (!panel) return
+    panel.focus()
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return
+      const focusable = panel.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )
+      if (focusable.length === 0) return
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    panel.addEventListener('keydown', handleKeyDown)
+    return () => panel.removeEventListener('keydown', handleKeyDown)
+  }, [showAddWorkout])
+
   // Get current goal for the year (memoized — used 3x in JSX)
   const currentGoal = useMemo<Goal | null>(() => 
     goals.find(g => g.year === currentYear) || null,
@@ -528,7 +556,7 @@ export function WorkoutDashboard() {
               <Check className="w-4 h-4" />
               {syncSuccess}
             </span>
-            <button onClick={() => setSyncSuccess(null)} className="text-green-500 hover:text-green-700 ml-4">
+            <button onClick={() => setSyncSuccess(null)} aria-label="Dismiss success message" className="text-green-500 hover:text-green-700 ml-4">
               <X className="w-4 h-4" />
             </button>
           </div>
@@ -539,7 +567,7 @@ export function WorkoutDashboard() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-4">
           <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg px-4 py-3 flex items-center justify-between">
             <span className="text-sm text-red-700 dark:text-red-300">{syncError}</span>
-            <button onClick={() => setSyncError(null)} className="text-red-500 hover:text-red-700 ml-4">
+            <button onClick={() => setSyncError(null)} aria-label="Dismiss error message" className="text-red-500 hover:text-red-700 ml-4">
               <X className="w-4 h-4" />
             </button>
           </div>
@@ -647,6 +675,7 @@ export function WorkoutDashboard() {
                   onClick={() => openEditGoal(currentGoal)}
                   className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                   title="Edit Goal"
+                  aria-label="Edit Goal"
                 >
                   <Target className="w-5 h-5" />
                 </button>
@@ -689,12 +718,13 @@ export function WorkoutDashboard() {
 
         {/* Modals */}
         {showAddWorkout && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-            <div className="bg-white dark:bg-gray-900 rounded-lg p-6 max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50" role="dialog" aria-modal="true" aria-labelledby="add-workout-title" onKeyDown={(e) => { if (e.key === 'Escape') setShowAddWorkout(false) }}>
+            <div ref={addWorkoutPanelRef} tabIndex={-1} className="bg-white dark:bg-gray-900 rounded-lg p-6 max-w-2xl w-full max-h-[90vh] overflow-y-auto">
               <div className="flex justify-between items-center mb-4">
-                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Add Workout</h2>
+                <h2 id="add-workout-title" className="text-xl font-bold text-gray-900 dark:text-white">Add Workout</h2>
                 <button
                   onClick={() => setShowAddWorkout(false)}
+                  aria-label="Close add workout dialog"
                   className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
                 >
                   <X className="w-6 h-6" />

--- a/src/components/WorkoutForm.tsx
+++ b/src/components/WorkoutForm.tsx
@@ -215,11 +215,12 @@ export function WorkoutForm({ onSubmit, initial, submitLabel = 'Add Workout' }: 
     <form onSubmit={handleSubmit(onFormSubmit)} className="grid grid-cols-1 gap-4">
       {/* Date */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        <label htmlFor="workout-date" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
           Date
         </label>
         <input
           type="date"
+          id="workout-date"
           {...register('date', { required: 'Date is required' })}
           className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 box-border"
           style={{ maxWidth: '100%' }}
@@ -229,10 +230,11 @@ export function WorkoutForm({ onSubmit, initial, submitLabel = 'Add Workout' }: 
 
       {/* Source */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        <label htmlFor="workout-source" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
           Source
         </label>
         <select
+          id="workout-source"
           {...register('source', { required: 'Source is required' })}
           onChange={(e) => {
             setValue('source', e.target.value);
@@ -256,10 +258,11 @@ export function WorkoutForm({ onSubmit, initial, submitLabel = 'Add Workout' }: 
 
       {/* Activity */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        <label htmlFor="workout-activity" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
           Activity
         </label>
         <select
+          id="workout-activity"
           {...register('activity', { required: 'Activity is required' })}
           disabled={!source}
           className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 disabled:bg-gray-100 dark:disabled:bg-gray-700 disabled:cursor-not-allowed"
@@ -274,13 +277,14 @@ export function WorkoutForm({ onSubmit, initial, submitLabel = 'Add Workout' }: 
 
       {/* Minutes */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        <label htmlFor="workout-minutes" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
           Minutes
         </label>
         <input
           type="number"
           step="any"
           placeholder="Minutes"
+          id="workout-minutes"
           {...register('minutes', { 
             required: 'Minutes is required',
             min: { value: 0, message: 'Minutes must be positive' }
@@ -293,13 +297,14 @@ export function WorkoutForm({ onSubmit, initial, submitLabel = 'Add Workout' }: 
       {/* Miles (conditional) */}
       {showMiles && (
         <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          <label htmlFor="workout-miles" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             Miles
           </label>
           <input
             type="number"
             step="any"
             placeholder="Miles"
+            id="workout-miles"
             {...register('miles', {
               min: { value: 0, message: 'Miles must be positive' }
             })}
@@ -311,11 +316,12 @@ export function WorkoutForm({ onSubmit, initial, submitLabel = 'Add Workout' }: 
       {/* Weight Lifted (conditional) */}
       {showWeight && (
         <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          <label htmlFor="workout-weight" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             Weight Lifted (lbs)
           </label>
           <input
             type="text"
+            id="workout-weight"
             placeholder="Weight (lbs)"
             value={formattedWeight}
             onChange={(e) => {
@@ -347,10 +353,11 @@ export function WorkoutForm({ onSubmit, initial, submitLabel = 'Add Workout' }: 
 
       {/* Notes */}
       <div className="col-span-full">
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        <label htmlFor="workout-notes" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
           Notes (optional)
         </label>
         <textarea
+          id="workout-notes"
           {...register('notes')}
           placeholder="Any additional notes..."
           rows={3}


### PR DESCRIPTION
## Accessibility Improvements

### Modals (3 files)
- **ARIA attributes**: `role="dialog"`, `aria-modal="true"`, `aria-labelledby` on all 3 modals (Add Workout, Settings, Goal)
- **Escape key**: All modals close on Escape
- **Focus traps**: Tab/Shift+Tab wraps within each modal
- **Close buttons**: `aria-label` on all close (X) buttons

### Icon-only buttons (7 total)
- `ThemeToggle`: `aria-label` on SSR placeholder + interactive button
- `DashboardHeader`: `aria-label` on Settings (mobile + desktop) and Import Tonal buttons
- `WorkoutDashboard`: `aria-label` on success/error banner dismiss buttons + Edit Goal button

### Form label associations (12 inputs)
- `WorkoutForm`: `htmlFor`/`id` on all 7 label/input pairs
- `GoalModal`: `htmlFor`/`id` on all 5 label/input pairs

### Settings radiogroup semantics
- 5 button groups (Cycling Speed, Outdoor Bonus, Units, Default Source, Default Activity) wrapped with `role="radiogroup"` + `aria-label`
- Individual buttons get `role="radio"` + `aria-checked`

### alert() → banner
- Delete workout error now uses `setSyncError()` banner instead of `alert()`

### Not changed (deferred)
- `prompt()` calls in Tonal OCR import flow — replacing these requires new modal UI for date/duration input during batch OCR. Low frequency (only triggered when OCR fails to parse date/duration from screenshots). Will address in a future PR.

### Build
✅ `next build` passes clean