### PR TITLE
Fix: Tonal sync missing minutes

### DIFF
--- a/src/app/api/tonal/sync/route.ts
+++ b/src/app/api/tonal/sync/route.ts
@@ -4,6 +4,7 @@ import { checkAuth } from '@/lib/auth'
 import {
   refreshTonalToken,
   fetchTonalActivitySummaries,
+  fetchTonalWorkoutActivity,
   mapTonalActivity,
   getUserIdFromToken,
 } from '@/lib/tonal'
@@ -142,7 +143,7 @@ export async function POST(req: Request) {
       const pageActivityIds = activities.map((a) => a.activityId ?? a.id).filter(Boolean) as string[]
       const alreadySynced = await prisma.workoutSession.findMany({
         where: { tonalWorkoutId: { in: pageActivityIds } },
-        select: { tonalWorkoutId: true },
+        select: { tonalWorkoutId: true, minutes: true },
       })
       const syncedIdSet = new Set(alreadySynced.map((r) => r.tonalWorkoutId))
 
@@ -155,6 +156,25 @@ export async function POST(req: Request) {
 
         // Check if already synced (batch lookup)
         if (syncedIdSet.has(tonalWorkoutId)) {
+          // Fix existing 0-minute entries by fetching detailed duration
+          const existingRow = alreadySynced.find((r) => r.tonalWorkoutId === tonalWorkoutId)
+          if (existingRow && existingRow.minutes === 0) {
+            try {
+              const token = pickBearerToken(cred)
+              const detailed = await fetchTonalWorkoutActivity(token, cred.userId, tonalWorkoutId)
+              if (detailed.duration_seconds > 0) {
+                const fixedMinutes = Math.round(detailed.duration_seconds / 60)
+                await prisma.workoutSession.updateMany({
+                  where: { tonalWorkoutId },
+                  data: { minutes: fixedMinutes },
+                })
+                console.log(`🔧 Fixed 0-minute Tonal workout ${tonalWorkoutId}: now ${fixedMinutes} min`)
+                updated++
+              }
+            } catch (e) {
+              console.warn(`⚠️ Could not fix 0-min workout ${tonalWorkoutId}:`, e instanceof Error ? e.message : e)
+            }
+          }
           skipped++
           continue
         }
@@ -162,7 +182,22 @@ export async function POST(req: Request) {
         // New workout
         newOnThisPage = true
 
-        const mapped = mapTonalActivity(activity)
+        // Check if summary has duration; if not, fetch detailed activity
+        const preview = activity.workoutPreview
+        const hasDuration = (preview?.durationSeconds ?? activity.duration_seconds ?? activity.duration) != null
+        let detailedDurationSec: number | undefined
+        if (!hasDuration) {
+          try {
+            const token = pickBearerToken(cred)
+            const detailed = await fetchTonalWorkoutActivity(token, cred.userId, tonalWorkoutId)
+            detailedDurationSec = detailed.duration_seconds
+            console.log(`📋 Fetched detailed duration for ${tonalWorkoutId}: ${detailedDurationSec}s`)
+          } catch (e) {
+            console.warn(`⚠️ Could not fetch detailed activity for ${tonalWorkoutId}:`, e instanceof Error ? e.message : e)
+          }
+        }
+
+        const mapped = mapTonalActivity(activity, detailedDurationSec)
 
         // Check for a manually-entered row matching date + source that
         // is missing tonalWorkoutId (backfill weight & link it)
@@ -183,6 +218,7 @@ export async function POST(req: Request) {
           await prisma.workoutSession.update({
             where: { id: manualMatch.id },
             data: {
+              minutes: mapped.minutes || manualMatch.minutes,
               weightLifted: mapped.weightLifted,
               notes: mapped.notes,
               tonalWorkoutId: mapped.tonalWorkoutId,

--- a/src/lib/tonal.ts
+++ b/src/lib/tonal.ts
@@ -226,10 +226,10 @@ export async function fetchTonalWorkoutActivity(
  *   - total_volume / total_volume_lbs
  *   - started_at for date
  */
-export function mapTonalActivity(activity: TonalActivityItem) {
+export function mapTonalActivity(activity: TonalActivityItem, detailedDurationSec?: number) {
   const preview = activity.workoutPreview
   const workoutName = preview?.workoutTitle ?? activity.name ?? activity.workout_name ?? 'Tonal Workout'
-  const durationSec = preview?.durationSeconds ?? activity.duration_seconds ?? activity.duration ?? 0
+  const durationSec = detailedDurationSec ?? preview?.durationSeconds ?? activity.duration_seconds ?? activity.duration ?? 0
   const minutes = Math.round(durationSec / 60)
   const totalVolume = preview?.totalVolume ?? activity.total_volume_lbs ?? activity.total_volume ?? 0
   const totalReps = preview?.totalReps ?? activity.total_reps ?? 0


### PR DESCRIPTION
## Problem

Some Tonal workouts sync with 0.0 minutes (visible on 5/4, 5/1, 4/18 in the screenshot). The `workoutPreview.durationSeconds` field isn't present for all Tonal workout types in the activity summary endpoint.

This was introduced in Phase 4 (PR #15) when we updated `mapTonalActivity` to read from `workoutPreview` first — the old code had the same gap but the Tonal API format change masked it.

## Fix

**1. Detailed activity fallback**: When the summary lacks duration, fetch the detailed `/workout-activities/:id` endpoint which has `duration_seconds` reliably. Only makes the extra API call when needed.

**2. Backfill existing 0-minute rows**: On next sync, any already-synced Tonal workout with 0 minutes gets its duration fetched from the detailed endpoint and updated in the DB.

**3. Manual-match backfill includes minutes**: The backfill path for manually-entered Tonal rows was updating `weightLifted`, `notes`, and `tonalWorkoutId` but not `minutes`.

## Files changed
- `src/lib/tonal.ts` — `mapTonalActivity` accepts optional `detailedDurationSec` param
- `src/app/api/tonal/sync/route.ts` — fallback fetch, 0-min repair, backfill fix

## Testing
Next Tonal sync should fix the 0-minute entries and correctly populate duration for future syncs.