### PR TITLE
Add .env.example with all required environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,69 @@
+# =============================================================================
+# FITNESS TRACKER — Environment Variables
+# =============================================================================
+# Copy this file to .env.local and fill in the values.
+#   cp .env.example .env.local
+#
+# Never commit real secrets. .env* is gitignored (except this example file).
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Database (PostgreSQL via Vercel Postgres / Neon)
+# -----------------------------------------------------------------------------
+# Pooled connection string — used by Prisma at runtime (prisma/schema.prisma)
+POSTGRES_PRISMA_URL="postgresql://user:password@host:5432/dbname?pgbouncer=true&connect_timeout=15"
+
+# Direct (non-pooled) connection — used by Prisma for migrations
+POSTGRES_URL_NON_POOLING="postgresql://user:password@host:5432/dbname?connect_timeout=15"
+
+# -----------------------------------------------------------------------------
+# Authentication (NextAuth.js)
+# -----------------------------------------------------------------------------
+# Secret used to sign/encrypt JWTs and session cookies (auth.ts, src/lib/auth.ts)
+# Generate with: openssl rand -base64 32
+NEXTAUTH_SECRET=""
+
+# Google OAuth 2.0 credentials (auth.ts)
+# Create at https://console.cloud.google.com/apis/credentials
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""
+
+# Single-user access control — only this email can sign in (auth.ts)
+ALLOWED_EMAIL=""
+
+# -----------------------------------------------------------------------------
+# MCP / API Authentication
+# -----------------------------------------------------------------------------
+# Bearer token for MCP and REST API access (src/lib/api-auth.ts, src/middleware.ts)
+# Generate with: openssl rand -hex 32
+MCP_API_TOKEN=""
+
+# -----------------------------------------------------------------------------
+# Credential Encryption
+# -----------------------------------------------------------------------------
+# AES-256-GCM key for encrypting stored third-party credentials (src/lib/crypto.ts)
+# Must be exactly 64 hex characters (32 bytes)
+# Generate with: openssl rand -hex 32
+CREDENTIAL_ENC_KEY=""
+
+# -----------------------------------------------------------------------------
+# Peloton Integration
+# -----------------------------------------------------------------------------
+# Peloton account credentials for workout sync (src/lib/peloton.ts)
+PELOTON_EMAIL=""
+PELOTON_PASSWORD=""
+
+# -----------------------------------------------------------------------------
+# Tonal Integration
+# -----------------------------------------------------------------------------
+# Tonal account credentials for workout sync (src/app/api/tonal/auth/route.ts)
+TONAL_EMAIL=""
+TONAL_PASSWORD=""
+
+# -----------------------------------------------------------------------------
+# App URL (optional)
+# -----------------------------------------------------------------------------
+# Explicit base URL added to the MCP CORS allow-list (src/app/api/mcp/[transport]/route.ts)
+# On Vercel this is auto-detected via VERCEL_URL; set this only for custom domains
+# or local development.
+APP_BASE_URL="http://localhost:3000"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
Adds a well-documented `.env.example` covering all 13 environment variables used in the codebase:

**Database**
- `POSTGRES_PRISMA_URL` — pooled connection (prisma/schema.prisma)
- `POSTGRES_URL_NON_POOLING` — direct connection for migrations (prisma/schema.prisma)

**Authentication**
- `NEXTAUTH_SECRET` — JWT signing (auth.ts, src/lib/auth.ts)
- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` — Google OAuth (auth.ts)
- `ALLOWED_EMAIL` — single-user access control (auth.ts)

**API / MCP**
- `MCP_API_TOKEN` — bearer token for MCP and REST API (src/lib/api-auth.ts, src/middleware.ts)

**Encryption**
- `CREDENTIAL_ENC_KEY` — AES-256-GCM key for stored credentials (src/lib/crypto.ts)

**Integrations**
- `PELOTON_EMAIL` / `PELOTON_PASSWORD` — Peloton sync (src/lib/peloton.ts)
- `TONAL_EMAIL` / `TONAL_PASSWORD` — Tonal sync (src/app/api/tonal/auth/route.ts)

**App URL**
- `APP_BASE_URL` — CORS origin for MCP (src/app/api/mcp/[transport]/route.ts)

Also updates `.gitignore` to add `!.env.example` so the template file is tracked despite the `.env*` glob.