### PR TITLE
rename(ui): Fitness Tracker -> Fit Track to fix mobile nav wrap

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,7 +9,7 @@ import { SessionProvider } from 'next-auth/react'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'Fitness Tracker',
+  title: 'Fit Track',
   description: 'Track your fitness journey',
   icons: {
     icon: '/fitness-logo.svg',

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -34,7 +34,7 @@ function LoginContent() {
               </svg>
             </div>
             <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
-              Fitness Tracker
+              Fit Track
             </h1>
             <p className="text-gray-600 dark:text-gray-400">
               Sign in to track your fitness journey

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -38,11 +38,11 @@ export function DashboardHeader({
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src="/fitness-logo.svg"
-                alt="Fitness Tracker"
+                alt="Fit Track"
                 className="w-8 h-8 rounded-lg shadow-sm"
               />
               <h1 className="text-base font-bold text-gray-900 dark:text-gray-100">
-                Fitness Tracker
+                Fit Track
               </h1>
             </div>
             <div className="flex items-center gap-1.5">
@@ -126,12 +126,12 @@ export function DashboardHeader({
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src="/fitness-logo.svg"
-              alt="Fitness Tracker"
+              alt="Fit Track"
               className="w-10 h-10 rounded-lg shadow-sm"
             />
             <div>
               <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100 whitespace-nowrap">
-                Fitness Tracker
+                Fit Track
               </h1>
               <p className="text-xs text-gray-600 dark:text-gray-400 whitespace-nowrap">Track your progress</p>
             </div>


### PR DESCRIPTION
## What
Renamed the app from "Fitness Tracker" to "Fit Track" everywhere it appears in the active web app UI: mobile header, desktop header, page `<title>` metadata, and the login screen heading. Logo alt text updated to match.

## Why
On mobile widths, the header `<h1>` (no `whitespace-nowrap`) wraps "Fitness Tracker" onto two lines, pushing the sync/settings buttons down. "Fit Track" fits on one line at the same width.

## Scope
- `src/components/DashboardHeader.tsx` (mobile + desktop headers, logo alt text)
- `src/app/layout.tsx` (page title metadata)
- `src/app/login/page.tsx` (login heading)

Left `archive/mobile/` (the old React Native app, `app.json`/`App.tsx`) untouched since it's archived and not part of the live Vercel app — flag if you want that renamed too.

Verified `tsc --noEmit` clean, no remaining "Fitness Tracker" references in `src/`.

---
🤖 Generated with a Coder Agents session.