### PR TITLE
feat(freeweights): progression, editable sets, and MCP tools (Phase 2)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,6 +101,21 @@ model MonthlySummary {
   @@map("monthly_summaries")
 }
 
+// Free Weights progression (Phase 2): per-exercise override of the code
+// defaults in src/lib/freeWeights.ts. A missing row means "use the code
+// default" — this table only ever stores exercises that have been bumped
+// at least once via Settings or the set_freeweight_progress MCP tool.
+model FreeWeightProgress {
+  id                String   @id @default(cuid())
+  exerciseId        String   @unique // slug from src/lib/freeWeights.ts, e.g. "push-overhead-press"
+  weightPerDumbbell Int // 5 | 10 | 15 | 20
+  reps              Int
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  @@map("free_weight_progress")
+}
+
 // Audit log (F-06) — every bearer-authed mutation, plus session mutations,
 // records a row here so a leaked MCP_API_TOKEN leaves a trail.
 model AuditLog {

--- a/src/app/api/freeweights/progress/route.ts
+++ b/src/app/api/freeweights/progress/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { requireAuth } from '@/lib/auth'
+import { WEIGHT_TIERS } from '@/lib/freeWeights'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const authResult = await requireAuth(request)
+  if (authResult instanceof NextResponse) return authResult
+
+  try {
+    const rows = await prisma.freeWeightProgress.findMany()
+    return NextResponse.json({ progress: rows })
+  } catch (error) {
+    console.error('Error fetching free weight progress:', error instanceof Error ? error.message : 'unknown')
+    return NextResponse.json({ error: 'Failed to fetch progress' }, { status: 500 })
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const authResult = await requireAuth(request)
+  if (authResult instanceof NextResponse) return authResult
+
+  try {
+    const body = await request.json()
+    const { exerciseId, reps, weightPerDumbbell } = body
+
+    if (!exerciseId || typeof exerciseId !== 'string') {
+      return NextResponse.json({ error: 'exerciseId is required' }, { status: 400 })
+    }
+    const parsedReps = parseInt(reps)
+    if (isNaN(parsedReps) || parsedReps < 1 || parsedReps > 100) {
+      return NextResponse.json({ error: 'reps must be between 1 and 100' }, { status: 400 })
+    }
+    const parsedWeight = parseInt(weightPerDumbbell)
+    if (!WEIGHT_TIERS.includes(parsedWeight as (typeof WEIGHT_TIERS)[number])) {
+      return NextResponse.json(
+        { error: `weightPerDumbbell must be one of ${WEIGHT_TIERS.join(', ')}` },
+        { status: 400 }
+      )
+    }
+
+    const updated = await prisma.freeWeightProgress.upsert({
+      where: { exerciseId },
+      update: { reps: parsedReps, weightPerDumbbell: parsedWeight },
+      create: { exerciseId, reps: parsedReps, weightPerDumbbell: parsedWeight },
+    })
+
+    return NextResponse.json({ progress: updated })
+  } catch (error) {
+    console.error('Error updating free weight progress:', error instanceof Error ? error.message : 'unknown')
+    return NextResponse.json({ error: 'Failed to update progress' }, { status: 500 })
+  }
+}

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -6,6 +6,7 @@ import { runPelotonSync } from '@/lib/peloton-sync'
 import { runTonalSync } from '@/lib/tonal-sync'
 import { limitMcp, limitSync } from '@/lib/rate-limit'
 import { logAudit } from '@/lib/audit-log'
+import { FREE_WEIGHT_ROUTINES, WEIGHT_TIERS, mergeProgress } from '@/lib/freeWeights'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300
@@ -191,6 +192,69 @@ const handler = createMcpHandler(
         const req = (extra as { request?: Request }).request
         if (req) await logAudit(req, null, 'mcp.delete_workout', { id })
         return { content: [{ type: 'text', text: JSON.stringify({ deleted: true, id, soft: true }) }] }
+      },
+    )
+
+    server.tool(
+      'list_freeweight_progress',
+      'List the current Free Weights travel-mode programming: every exercise across the ' +
+        'Push/Pull/Legs routines with its current dumbbell weight and reps/set, merging any ' +
+        'saved progression over the built-in defaults. Read-only; useful for reviewing how ' +
+        'programming has progressed over time.',
+      {},
+      async () => {
+        const rows = await prisma.freeWeightProgress.findMany()
+        const merged = mergeProgress(FREE_WEIGHT_ROUTINES, rows)
+        const exercises = merged.flatMap(routine =>
+          routine.exercises.map(ex => ({
+            routineId: routine.id,
+            routineName: routine.name,
+            exerciseId: ex.id,
+            name: ex.name,
+            load: ex.load,
+            sets: ex.sets,
+            reps: ex.reps,
+            weightPerDumbbell: ex.weightPerDumbbell,
+            isOverridden: rows.some(r => r.exerciseId === ex.id),
+          }))
+        )
+        return { content: [{ type: 'text', text: JSON.stringify({ exercises }, null, 2) }] }
+      },
+    )
+
+    server.tool(
+      'set_freeweight_progress',
+      'Update the current reps/set (and optionally dumbbell weight) baseline for one Free ' +
+        'Weights exercise. Weight must be one of the dumbbell pairs actually owned: 5, 10, 15, ' +
+        'or 20 lb. Use list_freeweight_progress first to find the exerciseId slug.',
+      {
+        exerciseId: z.string().min(1).describe('Exercise slug, e.g. "push-overhead-press".'),
+        reps: z.number().int().min(1).max(100),
+        weightPerDumbbell: z.union([z.literal(5), z.literal(10), z.literal(15), z.literal(20)])
+          .describe('One of the dumbbell pairs available: 5, 10, 15, or 20 lb.'),
+      },
+      async ({ exerciseId, reps, weightPerDumbbell }, extra) => {
+        const known = FREE_WEIGHT_ROUTINES.some(r => r.exercises.some(ex => ex.id === exerciseId))
+        if (!known) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'unknown_exercise_id', exerciseId }) }],
+            isError: true,
+          }
+        }
+        if (!WEIGHT_TIERS.includes(weightPerDumbbell)) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'invalid_weight', weightPerDumbbell }) }],
+            isError: true,
+          }
+        }
+        const updated = await prisma.freeWeightProgress.upsert({
+          where: { exerciseId },
+          update: { reps, weightPerDumbbell },
+          create: { exerciseId, reps, weightPerDumbbell },
+        })
+        const req = (extra as { request?: Request }).request
+        if (req) await logAudit(req, null, 'mcp.set_freeweight_progress', { exerciseId, reps, weightPerDumbbell })
+        return { content: [{ type: 'text', text: JSON.stringify({ progress: updated }, null, 2) }] }
       },
     )
 

--- a/src/app/freeweights/glossary/page.tsx
+++ b/src/app/freeweights/glossary/page.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { FREE_WEIGHT_ROUTINES } from '@/lib/freeWeights'
+import { NavTabs } from '@/components/NavTabs'
+import { ThemeToggle } from '@/components/ThemeToggle'
+
+// See src/app/page.tsx for why routes under /freeweights are force-dynamic:
+// middleware-based auth redirects don't run against a prerendered static shell.
+export const dynamic = 'force-dynamic'
+
+export default function FreeWeightsGlossaryPage() {
+  return (
+    <main className="min-h-screen bg-gray-50 dark:bg-gray-950">
+      <header className="bg-white dark:bg-gray-900 shadow-sm border-b border-gray-200 dark:border-gray-700 sticky top-0 z-50">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center justify-between gap-4">
+          <NavTabs />
+          <ThemeToggle />
+        </div>
+      </header>
+
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <Link
+          href="/freeweights"
+          className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 mb-4"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Free Weights
+        </Link>
+
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-1">Exercise Glossary</h1>
+        <p className="text-gray-600 dark:text-gray-400 mb-8">
+          What each exercise is and how to do it, before you start the timer.
+        </p>
+
+        {FREE_WEIGHT_ROUTINES.map(routine => (
+          <div key={routine.id} className="mb-8">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">{routine.name} Day</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{routine.description}</p>
+            <div className="space-y-4">
+              {routine.exercises.map(exercise => (
+                <div
+                  key={exercise.id}
+                  id={exercise.id}
+                  className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm scroll-mt-20"
+                >
+                  <div className="flex items-baseline justify-between mb-1.5 gap-2">
+                    <h3 className="font-semibold text-gray-900 dark:text-gray-100">{exercise.name}</h3>
+                    <span className="text-xs text-gray-500 dark:text-gray-400 shrink-0">
+                      {exercise.load === 'unilateral' ? 'one dumbbell, one side at a time' : 'both dumbbells together'}
+                    </span>
+                  </div>
+                  <p className="text-sm text-gray-600 dark:text-gray-300">{exercise.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -3,6 +3,7 @@
 import React, { useRef, useEffect, useCallback } from 'react'
 import { X } from 'lucide-react'
 import { useSettings } from '../context/SettingsContext'
+import { FreeWeightProgressSettings } from './freeweights/FreeWeightProgressSettings'
 
 interface SettingsModalProps {
   isOpen: boolean
@@ -166,6 +167,15 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
               🌍 Metric (km, kg)
             </button>
           </div>
+        </div>
+
+        {/* Free Weights Progression */}
+        <div className="mb-6">
+          <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Free Weights Progression</h3>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+            Bump reps/set as an exercise gets easier. Weight is capped by your dumbbells (5/10/15/20 lb).
+          </p>
+          <FreeWeightProgressSettings />
         </div>
 
         {/* Workout Defaults */}

--- a/src/components/freeweights/ActiveSession.tsx
+++ b/src/components/freeweights/ActiveSession.tsx
@@ -1,14 +1,22 @@
 'use client'
 
-import { Check, Clock, Weight, X } from 'lucide-react'
-import { perRepVolume, type FreeWeightRoutine } from '@/lib/freeWeights'
+import { useState } from 'react'
+import { Check, Clock, Weight, X, Pencil } from 'lucide-react'
+import { WEIGHT_TIERS, customSetVolume, type FreeWeightExercise, type FreeWeightRoutine } from '@/lib/freeWeights'
+
+export interface SetState {
+  completed: boolean
+  actualReps: number
+  actualWeight: number
+}
 
 interface ActiveSessionProps {
   routine: FreeWeightRoutine
-  checked: Record<string, boolean[]>
+  checked: Record<string, SetState[]>
   elapsedSeconds: number
   totalVolume: number
   onToggleSet: (exerciseId: string, setIndex: number) => void
+  onEditSet: (exerciseId: string, setIndex: number, actualReps: number, actualWeight: number) => void
   onFinish: () => void
   onCancel: () => void
 }
@@ -19,18 +27,97 @@ function formatElapsed(totalSeconds: number): string {
   return `${minutes}:${seconds.toString().padStart(2, '0')}`
 }
 
+function SetEditor({
+  exercise,
+  set,
+  onSave,
+  onClose,
+}: {
+  exercise: FreeWeightExercise
+  set: SetState
+  onSave: (actualReps: number, actualWeight: number) => void
+  onClose: () => void
+}) {
+  const [reps, setReps] = useState(set.actualReps)
+  const [weight, setWeight] = useState(set.actualWeight)
+
+  return (
+    <div className="mt-2 p-3 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between mb-2">
+        <label className="text-xs font-medium text-gray-600 dark:text-gray-300">Actual reps</label>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setReps(r => Math.max(0, r - 1))}
+            className="w-7 h-7 rounded-md bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200"
+          >
+            −
+          </button>
+          <span className="w-8 text-center font-semibold text-gray-900 dark:text-gray-100">{reps}</span>
+          <button
+            onClick={() => setReps(r => r + 1)}
+            className="w-7 h-7 rounded-md bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200"
+          >
+            +
+          </button>
+        </div>
+      </div>
+      <div className="flex items-center justify-between mb-3">
+        <label className="text-xs font-medium text-gray-600 dark:text-gray-300">Dumbbell used</label>
+        <div className="flex gap-1">
+          {WEIGHT_TIERS.map(tier => (
+            <button
+              key={tier}
+              onClick={() => setWeight(tier)}
+              className={`px-2 py-1 rounded-md text-xs font-semibold border ${
+                weight === tier
+                  ? 'bg-primary-600 border-primary-600 text-white'
+                  : 'bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300'
+              }`}
+            >
+              {tier}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <button
+          onClick={() => {
+            onSave(reps, weight)
+            onClose()
+          }}
+          className="flex-1 bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium py-1.5 rounded-md"
+        >
+          Save
+        </button>
+        <button
+          onClick={onClose}
+          className="px-3 text-sm text-gray-500 dark:text-gray-400"
+        >
+          Cancel
+        </button>
+      </div>
+      <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">
+        Planned: {exercise.reps} reps × {exercise.weightPerDumbbell} lb. One-off for this set only.
+      </p>
+    </div>
+  )
+}
+
 export function ActiveSession({
   routine,
   checked,
   elapsedSeconds,
   totalVolume,
   onToggleSet,
+  onEditSet,
   onFinish,
   onCancel,
 }: ActiveSessionProps) {
+  const [editing, setEditing] = useState<{ exerciseId: string; setIndex: number } | null>(null)
+
   const totalSets = routine.exercises.reduce((sum, ex) => sum + ex.sets, 0)
   const completedSets = routine.exercises.reduce(
-    (sum, ex) => sum + (checked[ex.id]?.filter(Boolean).length ?? 0),
+    (sum, ex) => sum + (checked[ex.id]?.filter(s => s.completed).length ?? 0),
     0
   )
   const anySetCompleted = completedSets > 0
@@ -68,8 +155,7 @@ export function ActiveSession({
 
       <div className="space-y-4">
         {routine.exercises.map(exercise => {
-          const volumePerRep = perRepVolume(exercise)
-          const exerciseChecked = checked[exercise.id] ?? Array(exercise.sets).fill(false)
+          const exerciseSets = checked[exercise.id] ?? []
           return (
             <div
               key={exercise.id}
@@ -82,30 +168,55 @@ export function ActiveSession({
                 </span>
               </div>
               <div className="flex flex-wrap gap-2">
-                {exerciseChecked.map((isChecked, setIndex) => (
-                  <button
-                    key={setIndex}
-                    onClick={() => onToggleSet(exercise.id, setIndex)}
-                    aria-pressed={isChecked}
-                    className={`flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium border transition-colors ${
-                      isChecked
-                        ? 'bg-primary-600 border-primary-600 text-white'
-                        : 'bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:border-primary-400'
-                    }`}
-                  >
-                    <span
-                      className={`w-4 h-4 rounded-sm border flex items-center justify-center ${
-                        isChecked ? 'bg-white border-white' : 'border-gray-400'
-                      }`}
-                    >
-                      {isChecked && <Check className="w-3 h-3 text-primary-600" />}
-                    </span>
-                    Set {setIndex + 1}
-                  </button>
-                ))}
+                {exerciseSets.map((set, setIndex) => {
+                  const isEditingThis = editing?.exerciseId === exercise.id && editing.setIndex === setIndex
+                  const modified = set.actualReps !== exercise.reps || set.actualWeight !== exercise.weightPerDumbbell
+                  return (
+                    <div key={setIndex} className={isEditingThis ? 'w-full' : ''}>
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => onToggleSet(exercise.id, setIndex)}
+                          aria-pressed={set.completed}
+                          className={`flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium border transition-colors ${
+                            set.completed
+                              ? 'bg-primary-600 border-primary-600 text-white'
+                              : 'bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:border-primary-400'
+                          }`}
+                        >
+                          <span
+                            className={`w-4 h-4 rounded-sm border flex items-center justify-center ${
+                              set.completed ? 'bg-white border-white' : 'border-gray-400'
+                            }`}
+                          >
+                            {set.completed && <Check className="w-3 h-3 text-primary-600" />}
+                          </span>
+                          Set {setIndex + 1}
+                          {modified && <span className="text-[10px] opacity-80">*</span>}
+                        </button>
+                        <button
+                          onClick={() => setEditing(isEditingThis ? null : { exerciseId: exercise.id, setIndex })}
+                          className="p-2 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800"
+                          aria-label={`Edit set ${setIndex + 1} for ${exercise.name}`}
+                          title="Edit reps/weight for this set"
+                        >
+                          <Pencil className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                      {isEditingThis && (
+                        <SetEditor
+                          exercise={exercise}
+                          set={set}
+                          onSave={(actualReps, actualWeight) => onEditSet(exercise.id, setIndex, actualReps, actualWeight)}
+                          onClose={() => setEditing(null)}
+                        />
+                      )}
+                    </div>
+                  )
+                })}
               </div>
               <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">
-                {volumePerRep} lb/rep planned
+                {customSetVolume(exercise, exercise.reps, exercise.weightPerDumbbell)} lb/set planned
+                {exerciseSets.some(s => s.actualReps !== exercise.reps || s.actualWeight !== exercise.weightPerDumbbell) && ' · * = edited for this session'}
               </p>
             </div>
           )

--- a/src/components/freeweights/ActiveSession.tsx
+++ b/src/components/freeweights/ActiveSession.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import { Check, Clock, Weight, X, Pencil } from 'lucide-react'
+import Link from 'next/link'
+import { Check, Clock, Weight, X, Pencil, BookOpen } from 'lucide-react'
 import { WEIGHT_TIERS, customSetVolume, type FreeWeightExercise, type FreeWeightRoutine } from '@/lib/freeWeights'
 
 export interface SetState {
@@ -162,7 +163,18 @@ export function ActiveSession({
               className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm"
             >
               <div className="flex items-baseline justify-between mb-3">
-                <h3 className="font-semibold text-gray-900 dark:text-gray-100">{exercise.name}</h3>
+                <h3 className="font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-1.5">
+                  {exercise.name}
+                  <Link
+                    href={`/freeweights/glossary#${exercise.id}`}
+                    target="_blank"
+                    className="text-gray-400 hover:text-primary-500"
+                    aria-label={`What is ${exercise.name}?`}
+                    title="What is this exercise?"
+                  >
+                    <BookOpen className="w-3.5 h-3.5" />
+                  </Link>
+                </h3>
                 <span className="text-xs text-gray-500 dark:text-gray-400">
                   {exercise.weightPerDumbbell} lb {exercise.load === 'bilateral' ? '(each)' : ''} · {exercise.reps} reps
                 </span>

--- a/src/components/freeweights/FreeWeightProgressSettings.tsx
+++ b/src/components/freeweights/FreeWeightProgressSettings.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { TrendingUp } from 'lucide-react'
+import {
+  FREE_WEIGHT_ROUTINES,
+  REP_CEILING,
+  LEVEL_UP_RESET_REPS,
+  mergeProgress,
+  nextWeightTier,
+  type FreeWeightProgressRow,
+  type FreeWeightRoutine,
+} from '@/lib/freeWeights'
+
+/**
+ * Phase 2 progression control. Weight is capped by the dumbbells you
+ * actually own (5/10/15/20 lb pairs), so only reps/set is adjustable here.
+ * Once an exercise hits REP_CEILING at a weight below the heaviest tier,
+ * a "Level Up" prompt offers to move to the next dumbbell size and reset
+ * reps to a restart baseline, rather than let reps climb forever on light
+ * weight.
+ */
+export function FreeWeightProgressSettings() {
+  const [routines, setRoutines] = useState<FreeWeightRoutine[]>(FREE_WEIGHT_ROUTINES)
+  const [loading, setLoading] = useState(true)
+  const [pendingId, setPendingId] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/freeweights/progress')
+      .then(res => (res.ok ? res.json() : { progress: [] }))
+      .then((data: { progress: FreeWeightProgressRow[] }) => {
+        if (cancelled) return
+        setRoutines(mergeProgress(FREE_WEIGHT_ROUTINES, data.progress ?? []))
+      })
+      .catch(() => {
+        // Keep code defaults.
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const patch = async (exerciseId: string, reps: number, weightPerDumbbell: number) => {
+    setPendingId(exerciseId)
+    try {
+      const res = await fetch('/api/freeweights/progress', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ exerciseId, reps, weightPerDumbbell }),
+      })
+      if (!res.ok) return
+      setRoutines(prev =>
+        prev.map(r => ({
+          ...r,
+          exercises: r.exercises.map(ex =>
+            ex.id === exerciseId ? { ...ex, reps, weightPerDumbbell: weightPerDumbbell as typeof ex.weightPerDumbbell } : ex
+          ),
+        }))
+      )
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  if (loading) {
+    return (
+      <p className="text-sm text-gray-500 dark:text-gray-400">Loading progression…</p>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {routines.map(routine => (
+        <div key={routine.id}>
+          <p className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1.5">
+            {routine.name} Day
+          </p>
+          <div className="space-y-2">
+            {routine.exercises.map(exercise => {
+              const canLevelUp = exercise.reps >= REP_CEILING && nextWeightTier(exercise.weightPerDumbbell) !== null
+              const maxed = exercise.weightPerDumbbell === 20
+              const disabled = pendingId === exercise.id
+
+              return (
+                <div key={exercise.id} className="flex items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="text-sm text-gray-800 dark:text-gray-200 truncate">{exercise.name}</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      {exercise.weightPerDumbbell} lb · {exercise.reps} reps/set
+                      {maxed && exercise.reps >= REP_CEILING && ' · maxed at 20 lb'}
+                    </p>
+                  </div>
+                  {canLevelUp ? (
+                    <button
+                      disabled={disabled}
+                      onClick={() => patch(exercise.id, LEVEL_UP_RESET_REPS, nextWeightTier(exercise.weightPerDumbbell)!)}
+                      className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-semibold bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400 hover:bg-primary-100 dark:hover:bg-primary-900/50 disabled:opacity-50 shrink-0"
+                    >
+                      <TrendingUp className="w-3.5 h-3.5" />
+                      Level up to {nextWeightTier(exercise.weightPerDumbbell)} lb
+                    </button>
+                  ) : (
+                    <div className="flex items-center gap-1 shrink-0">
+                      <button
+                        disabled={disabled || exercise.reps <= 1}
+                        onClick={() => patch(exercise.id, exercise.reps - 1, exercise.weightPerDumbbell)}
+                        className="w-7 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 disabled:opacity-40"
+                      >
+                        −
+                      </button>
+                      <button
+                        disabled={disabled}
+                        onClick={() => patch(exercise.id, exercise.reps + 1, exercise.weightPerDumbbell)}
+                        className="w-7 h-7 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 disabled:opacity-40"
+                      >
+                        +
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/freeweights/FreeWeightsMode.tsx
+++ b/src/components/freeweights/FreeWeightsMode.tsx
@@ -2,11 +2,13 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { RoutinePicker } from './RoutinePicker'
-import { ActiveSession } from './ActiveSession'
+import { ActiveSession, type SetState } from './ActiveSession'
 import { SessionSummary } from './SessionSummary'
 import {
-  getRoutine,
-  setVolume,
+  FREE_WEIGHT_ROUTINES,
+  customSetVolume,
+  mergeProgress,
+  type FreeWeightProgressRow,
   type FreeWeightRoutine,
 } from '@/lib/freeWeights'
 
@@ -17,11 +19,20 @@ const STORAGE_KEY = 'fitness-tracker-freeweights-session'
 interface PersistedSession {
   routineId: string
   startedAt: number
-  checked: Record<string, boolean[]>
+  checked: Record<string, SetState[]>
 }
 
-function emptyChecked(routine: FreeWeightRoutine): Record<string, boolean[]> {
-  return Object.fromEntries(routine.exercises.map(ex => [ex.id, Array(ex.sets).fill(false)]))
+function initialSets(routine: FreeWeightRoutine): Record<string, SetState[]> {
+  return Object.fromEntries(
+    routine.exercises.map(ex => [
+      ex.id,
+      Array.from({ length: ex.sets }, () => ({
+        completed: false,
+        actualReps: ex.reps,
+        actualWeight: ex.weightPerDumbbell,
+      })),
+    ])
+  )
 }
 
 function loadPersistedSession(): PersistedSession | null {
@@ -29,7 +40,7 @@ function loadPersistedSession(): PersistedSession | null {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return null
     const parsed = JSON.parse(raw) as PersistedSession
-    if (!parsed.routineId || !getRoutine(parsed.routineId)) return null
+    if (!parsed.routineId) return null
     return parsed
   } catch {
     return null
@@ -53,9 +64,14 @@ function clearPersistedSession() {
 }
 
 export function FreeWeightsMode() {
+  // Code defaults, overlaid with DB progression once it loads (see effect
+  // below). Kept as state — rather than a plain constant — so an
+  // in-progress or just-finished session always reflects the current
+  // baseline, not a stale snapshot from before the fetch resolved.
+  const [routines, setRoutines] = useState<FreeWeightRoutine[]>(FREE_WEIGHT_ROUTINES)
   const [screen, setScreen] = useState<Screen>('picker')
-  const [routine, setRoutine] = useState<FreeWeightRoutine | null>(null)
-  const [checked, setChecked] = useState<Record<string, boolean[]>>({})
+  const [routineId, setRoutineId] = useState<string | null>(null)
+  const [checked, setChecked] = useState<Record<string, SetState[]>>({})
   const [startedAt, setStartedAt] = useState<number | null>(null)
   const [elapsedSeconds, setElapsedSeconds] = useState(0)
   const [finishedElapsedSeconds, setFinishedElapsedSeconds] = useState(0)
@@ -63,13 +79,35 @@ export function FreeWeightsMode() {
   const [saved, setSaved] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  const routine = useMemo(
+    () => (routineId ? routines.find(r => r.id === routineId) ?? null : null),
+    [routines, routineId]
+  )
+
+  // Fetch current progression (Phase 2) and overlay it onto the code
+  // defaults. Falls back silently to defaults if the fetch fails so this
+  // never blocks starting a workout.
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/freeweights/progress')
+      .then(res => (res.ok ? res.json() : { progress: [] }))
+      .then((data: { progress: FreeWeightProgressRow[] }) => {
+        if (cancelled) return
+        setRoutines(mergeProgress(FREE_WEIGHT_ROUTINES, data.progress ?? []))
+      })
+      .catch(() => {
+        // Keep code defaults.
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
   // Restore an in-progress session (e.g. after an accidental tab close) on mount.
   useEffect(() => {
     const persisted = loadPersistedSession()
     if (!persisted) return
-    const restoredRoutine = getRoutine(persisted.routineId)
-    if (!restoredRoutine) return
-    setRoutine(restoredRoutine)
+    setRoutineId(persisted.routineId)
     setChecked(persisted.checked)
     setStartedAt(persisted.startedAt)
     setScreen('active')
@@ -88,21 +126,17 @@ export function FreeWeightsMode() {
     if (!routine) return 0
     return routine.exercises.reduce((sum, ex) => {
       const sets = checked[ex.id] ?? []
-      const completedReps = sets.filter(Boolean).length * ex.reps
-      return sum + setVolume(ex, completedReps)
+      const completedVolume = sets
+        .filter(s => s.completed)
+        .reduce((setSum, s) => setSum + customSetVolume(ex, s.actualReps, s.actualWeight), 0)
+      return sum + completedVolume
     }, 0)
   }, [routine, checked])
 
-  const setsCompleted = useMemo(
-    () => Object.values(checked).reduce((sum, sets) => sum + sets.filter(Boolean).length, 0),
-    [checked]
-  )
-  const totalSets = routine?.exercises.reduce((sum, ex) => sum + ex.sets, 0) ?? 0
-
   const handleSelectRoutine = useCallback((selected: FreeWeightRoutine) => {
-    const initialChecked = emptyChecked(selected)
+    const initialChecked = initialSets(selected)
     const now = Date.now()
-    setRoutine(selected)
+    setRoutineId(selected.id)
     setChecked(initialChecked)
     setStartedAt(now)
     setElapsedSeconds(0)
@@ -117,15 +151,31 @@ export function FreeWeightsMode() {
       setChecked(prev => {
         const next = {
           ...prev,
-          [exerciseId]: prev[exerciseId].map((v, i) => (i === setIndex ? !v : v)),
+          [exerciseId]: prev[exerciseId].map((s, i) => (i === setIndex ? { ...s, completed: !s.completed } : s)),
         }
-        if (routine && startedAt !== null) {
-          savePersistedSession({ routineId: routine.id, startedAt, checked: next })
+        if (routineId && startedAt !== null) {
+          savePersistedSession({ routineId, startedAt, checked: next })
         }
         return next
       })
     },
-    [routine, startedAt]
+    [routineId, startedAt]
+  )
+
+  const handleEditSet = useCallback(
+    (exerciseId: string, setIndex: number, actualReps: number, actualWeight: number) => {
+      setChecked(prev => {
+        const next = {
+          ...prev,
+          [exerciseId]: prev[exerciseId].map((s, i) => (i === setIndex ? { ...s, actualReps, actualWeight } : s)),
+        }
+        if (routineId && startedAt !== null) {
+          savePersistedSession({ routineId, startedAt, checked: next })
+        }
+        return next
+      })
+    },
+    [routineId, startedAt]
   )
 
   const handleFinish = useCallback(() => {
@@ -134,14 +184,19 @@ export function FreeWeightsMode() {
     setScreen('summary')
   }, [elapsedSeconds])
 
-  const handleCancel = useCallback(() => {
-    clearPersistedSession()
-    setRoutine(null)
+  const resetToPicker = useCallback(() => {
+    setRoutineId(null)
     setChecked({})
     setStartedAt(null)
     setElapsedSeconds(0)
+    setFinishedElapsedSeconds(0)
     setScreen('picker')
   }, [])
+
+  const handleCancel = useCallback(() => {
+    clearPersistedSession()
+    resetToPicker()
+  }, [resetToPicker])
 
   const elapsedMinutes = Math.max(1, Math.round(finishedElapsedSeconds / 60))
 
@@ -150,7 +205,7 @@ export function FreeWeightsMode() {
     setSaving(true)
     setError(null)
     try {
-      const touchedExercises = routine.exercises.filter(ex => (checked[ex.id] ?? []).some(Boolean))
+      const touchedExercises = routine.exercises.filter(ex => (checked[ex.id] ?? []).some(s => s.completed))
       const notes = `${routine.name} Day (Free Weights) — ${touchedExercises.map(ex => ex.name).join(', ')}`
 
       const res = await fetch('/api/workouts', {
@@ -180,23 +235,13 @@ export function FreeWeightsMode() {
   }, [routine, checked, elapsedMinutes, totalVolume])
 
   const handleDiscard = useCallback(() => {
-    setRoutine(null)
-    setChecked({})
-    setStartedAt(null)
-    setElapsedSeconds(0)
-    setFinishedElapsedSeconds(0)
-    setScreen('picker')
-  }, [])
+    resetToPicker()
+  }, [resetToPicker])
 
   const handleDone = useCallback(() => {
-    setRoutine(null)
-    setChecked({})
-    setStartedAt(null)
-    setElapsedSeconds(0)
-    setFinishedElapsedSeconds(0)
     setSaved(false)
-    setScreen('picker')
-  }, [])
+    resetToPicker()
+  }, [resetToPicker])
 
   if (screen === 'active' && routine) {
     return (
@@ -206,6 +251,7 @@ export function FreeWeightsMode() {
         elapsedSeconds={elapsedSeconds}
         totalVolume={totalVolume}
         onToggleSet={handleToggleSet}
+        onEditSet={handleEditSet}
         onFinish={handleFinish}
         onCancel={handleCancel}
       />
@@ -216,10 +262,9 @@ export function FreeWeightsMode() {
     return (
       <SessionSummary
         routine={routine}
+        checked={checked}
         elapsedMinutes={elapsedMinutes}
         totalVolume={totalVolume}
-        setsCompleted={setsCompleted}
-        totalSets={totalSets}
         saving={saving}
         error={error}
         saved={saved}
@@ -230,5 +275,5 @@ export function FreeWeightsMode() {
     )
   }
 
-  return <RoutinePicker onSelect={handleSelectRoutine} />
+  return <RoutinePicker routines={routines} onSelect={handleSelectRoutine} />
 }

--- a/src/components/freeweights/RoutinePicker.tsx
+++ b/src/components/freeweights/RoutinePicker.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { Dumbbell, Clock, ChevronRight } from 'lucide-react'
+import Link from 'next/link'
+import { Dumbbell, Clock, ChevronRight, BookOpen } from 'lucide-react'
 import { estimateRoutineMinutes, plannedRoutineVolume, type FreeWeightRoutine } from '@/lib/freeWeights'
 
 interface RoutinePickerProps {
@@ -16,14 +17,29 @@ export function RoutinePicker({ routines, onSelect }: RoutinePickerProps) {
         <p className="text-gray-600 dark:text-gray-400 mt-1">
           Dumbbell-only routines for when you&apos;re away from Tonal. Pick a day to start.
         </p>
+        <Link
+          href="/freeweights/glossary"
+          className="inline-flex items-center gap-1.5 text-sm text-primary-600 dark:text-primary-400 hover:underline mt-2"
+        >
+          <BookOpen className="w-4 h-4" />
+          Not sure what an exercise is? Read the glossary
+        </Link>
       </div>
 
       <div className="grid gap-4 sm:grid-cols-3">
         {routines.map(routine => (
-          <button
+          <div
             key={routine.id}
+            role="button"
+            tabIndex={0}
             onClick={() => onSelect(routine)}
-            className="text-left bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-5 shadow-sm hover:shadow-md hover:border-primary-400 dark:hover:border-primary-500 transition-all group"
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                onSelect(routine)
+              }
+            }}
+            className="text-left bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-5 shadow-sm hover:shadow-md hover:border-primary-400 dark:hover:border-primary-500 transition-all group cursor-pointer"
           >
             <div className="flex items-center justify-between mb-2">
               <div className="w-10 h-10 rounded-lg bg-primary-50 dark:bg-primary-900/30 flex items-center justify-center">
@@ -36,7 +52,15 @@ export function RoutinePicker({ routines, onSelect }: RoutinePickerProps) {
             <ul className="text-sm text-gray-600 dark:text-gray-300 space-y-0.5 mb-3">
               {routine.exercises.map(ex => (
                 <li key={ex.id}>
-                  {ex.name} — {ex.sets}×{ex.reps}
+                  <Link
+                    href={`/freeweights/glossary#${ex.id}`}
+                    target="_blank"
+                    onClick={e => e.stopPropagation()}
+                    className="hover:text-primary-600 dark:hover:text-primary-400 hover:underline"
+                  >
+                    {ex.name}
+                  </Link>
+                  {' '}— {ex.sets}×{ex.reps}
                 </li>
               ))}
             </ul>
@@ -47,7 +71,7 @@ export function RoutinePicker({ routines, onSelect }: RoutinePickerProps) {
               </span>
               <span>~{plannedRoutineVolume(routine).toLocaleString()} lbs</span>
             </div>
-          </button>
+          </div>
         ))}
       </div>
     </div>

--- a/src/components/freeweights/RoutinePicker.tsx
+++ b/src/components/freeweights/RoutinePicker.tsx
@@ -1,13 +1,14 @@
 'use client'
 
 import { Dumbbell, Clock, ChevronRight } from 'lucide-react'
-import { FREE_WEIGHT_ROUTINES, estimateRoutineMinutes, plannedRoutineVolume, type FreeWeightRoutine } from '@/lib/freeWeights'
+import { estimateRoutineMinutes, plannedRoutineVolume, type FreeWeightRoutine } from '@/lib/freeWeights'
 
 interface RoutinePickerProps {
+  routines: FreeWeightRoutine[]
   onSelect: (routine: FreeWeightRoutine) => void
 }
 
-export function RoutinePicker({ onSelect }: RoutinePickerProps) {
+export function RoutinePicker({ routines, onSelect }: RoutinePickerProps) {
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">
       <div className="mb-6 text-center">
@@ -18,7 +19,7 @@ export function RoutinePicker({ onSelect }: RoutinePickerProps) {
       </div>
 
       <div className="grid gap-4 sm:grid-cols-3">
-        {FREE_WEIGHT_ROUTINES.map(routine => (
+        {routines.map(routine => (
           <button
             key={routine.id}
             onClick={() => onSelect(routine)}

--- a/src/components/freeweights/SessionSummary.tsx
+++ b/src/components/freeweights/SessionSummary.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { CheckCircle2, AlertCircle } from 'lucide-react'
+import { CheckCircle2, AlertCircle, AlertTriangle } from 'lucide-react'
 import type { FreeWeightRoutine } from '@/lib/freeWeights'
+import type { SetState } from './ActiveSession'
 
 interface SessionSummaryProps {
   routine: FreeWeightRoutine
+  checked: Record<string, SetState[]>
   elapsedMinutes: number
   totalVolume: number
-  setsCompleted: number
-  totalSets: number
   saving: boolean
   error: string | null
   saved: boolean
@@ -19,10 +19,9 @@ interface SessionSummaryProps {
 
 export function SessionSummary({
   routine,
+  checked,
   elapsedMinutes,
   totalVolume,
-  setsCompleted,
-  totalSets,
   saving,
   error,
   saved,
@@ -30,6 +29,25 @@ export function SessionSummary({
   onDiscard,
   onDone,
 }: SessionSummaryProps) {
+  const totalSets = routine.exercises.reduce((sum, ex) => sum + ex.sets, 0)
+  const setsCompleted = Object.values(checked).reduce(
+    (sum, sets) => sum + sets.filter(s => s.completed).length,
+    0
+  )
+
+  // "Don't regress" check: compare completed reps against the current
+  // baseline (planned reps × completed sets) per exercise. Flags — never
+  // blocks — anything that came in under the baseline you set for yourself.
+  const belowBaseline = routine.exercises
+    .map(exercise => {
+      const sets = checked[exercise.id] ?? []
+      const completedSets = sets.filter(s => s.completed)
+      const baselineReps = exercise.reps * completedSets.length
+      const actualReps = completedSets.reduce((sum, s) => sum + s.actualReps, 0)
+      return { exercise, baselineReps, actualReps, completedSetCount: completedSets.length }
+    })
+    .filter(({ baselineReps, actualReps, completedSetCount }) => completedSetCount > 0 && actualReps < baselineReps)
+
   return (
     <div className="max-w-md mx-auto px-4 py-10 text-center">
       <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-1">
@@ -49,6 +67,22 @@ export function SessionSummary({
           <p className="text-xs text-gray-500 dark:text-gray-400">lbs lifted</p>
         </div>
       </div>
+
+      {belowBaseline.length > 0 && (
+        <div className="mb-6 text-left bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3">
+          <div className="flex items-center gap-2 text-amber-700 dark:text-amber-400 font-medium text-sm mb-1">
+            <AlertTriangle className="w-4 h-4" />
+            Below your current baseline
+          </div>
+          <ul className="text-sm text-amber-700 dark:text-amber-400 space-y-0.5">
+            {belowBaseline.map(({ exercise, baselineReps, actualReps }) => (
+              <li key={exercise.id}>
+                {exercise.name}: {actualReps}/{baselineReps} reps
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {saved ? (
         <div className="flex flex-col items-center gap-3">

--- a/src/lib/freeWeights.ts
+++ b/src/lib/freeWeights.ts
@@ -17,6 +17,10 @@ export interface FreeWeightExercise {
    * the future DB foreign key — do not change once shipped. */
   id: string
   name: string
+  /** Two-sentence, no-jargon how-to. Shown in the exercise glossary and
+   * linked from the routine picker / active session for anyone (including
+   * future-you) who forgets what a "Floor Chest Fly" is. */
+  description: string
   /**
    * How weight is loaded per rep:
    * - bilateral: both dumbbells move together every rep. Volume/rep = 2 * weightPerDumbbell.
@@ -75,11 +79,36 @@ export const FREE_WEIGHT_ROUTINES: FreeWeightRoutine[] = [
     name: 'Push',
     description: 'Chest, shoulders, triceps',
     exercises: [
-      { id: 'push-overhead-press', name: 'Standing Overhead Press', load: 'bilateral', weightPerDumbbell: 15, sets: 5, reps: 15 },
-      { id: 'push-floor-chest-press', name: 'Floor Chest Press', load: 'bilateral', weightPerDumbbell: 20, sets: 5, reps: 15 },
-      { id: 'push-floor-chest-fly', name: 'Floor Chest Fly', load: 'bilateral', weightPerDumbbell: 10, sets: 5, reps: 15 },
-      { id: 'push-lateral-raise', name: 'Lateral Raise', load: 'bilateral', weightPerDumbbell: 5, sets: 5, reps: 15 },
-      { id: 'push-triceps-kickback', name: 'Triceps Kickback', load: 'unilateral', weightPerDumbbell: 10, sets: 5, reps: 15 },
+      {
+        id: 'push-overhead-press',
+        name: 'Standing Overhead Press',
+        description: 'Stand with feet shoulder-width apart, holding a dumbbell in each hand at shoulder height with palms facing forward. Press both dumbbells straight overhead until your arms are fully extended, then lower back to shoulder height with control.',
+        load: 'bilateral', weightPerDumbbell: 15, sets: 5, reps: 15,
+      },
+      {
+        id: 'push-floor-chest-press',
+        name: 'Floor Chest Press',
+        description: 'Lie on your back on the floor with knees bent, holding a dumbbell in each hand at chest level with elbows bent. Press both dumbbells straight up until your arms are extended, then lower until your upper arms touch the floor.',
+        load: 'bilateral', weightPerDumbbell: 20, sets: 5, reps: 15,
+      },
+      {
+        id: 'push-floor-chest-fly',
+        name: 'Floor Chest Fly',
+        description: "Lie on your back on the floor with a slight bend in your elbows, arms extended out to the sides at chest level holding a dumbbell in each hand. Bring the dumbbells together in an arc over your chest, then lower back out to the sides with control.",
+        load: 'bilateral', weightPerDumbbell: 10, sets: 5, reps: 15,
+      },
+      {
+        id: 'push-lateral-raise',
+        name: 'Lateral Raise',
+        description: "Stand with a dumbbell in each hand at your sides, palms facing your body. Raise both arms out to the sides until they're roughly shoulder height, then lower with control.",
+        load: 'bilateral', weightPerDumbbell: 5, sets: 5, reps: 15,
+      },
+      {
+        id: 'push-triceps-kickback',
+        name: 'Triceps Kickback',
+        description: 'Hinge forward at the hips with a flat back, holding a dumbbell in one hand with your upper arm pinned close to your torso and elbow bent. Extend your forearm straight back until your arm is fully straight, then bend it back to the start.',
+        load: 'unilateral', weightPerDumbbell: 10, sets: 5, reps: 15,
+      },
     ],
   },
   {
@@ -87,11 +116,36 @@ export const FREE_WEIGHT_ROUTINES: FreeWeightRoutine[] = [
     name: 'Pull',
     description: 'Back, biceps, rear delts',
     exercises: [
-      { id: 'pull-bent-over-row', name: 'Bent-Over Row', load: 'bilateral', weightPerDumbbell: 20, sets: 5, reps: 15 },
-      { id: 'pull-single-arm-row', name: 'Single-Arm Row', load: 'unilateral', weightPerDumbbell: 20, sets: 5, reps: 15 },
-      { id: 'pull-bicep-curl', name: 'Bicep Curl', load: 'bilateral', weightPerDumbbell: 10, sets: 5, reps: 15 },
-      { id: 'pull-hammer-curl', name: 'Hammer Curl', load: 'bilateral', weightPerDumbbell: 10, sets: 5, reps: 15 },
-      { id: 'pull-rear-delt-fly', name: 'Rear Delt Fly', load: 'bilateral', weightPerDumbbell: 5, sets: 5, reps: 15 },
+      {
+        id: 'pull-bent-over-row',
+        name: 'Bent-Over Row',
+        description: 'Hinge forward at the hips with a flat back and knees slightly bent, holding a dumbbell in each hand hanging below your shoulders. Pull both dumbbells up toward your ribcage, squeezing your shoulder blades together, then lower with control.',
+        load: 'bilateral', weightPerDumbbell: 20, sets: 5, reps: 15,
+      },
+      {
+        id: 'pull-single-arm-row',
+        name: 'Single-Arm Row',
+        description: 'Hinge forward at the hips with a flat back, holding a dumbbell in one hand hanging straight down while the other hand rests on your thigh for support. Pull the dumbbell up toward your ribcage, then lower it back down with control.',
+        load: 'unilateral', weightPerDumbbell: 20, sets: 5, reps: 15,
+      },
+      {
+        id: 'pull-bicep-curl',
+        name: 'Bicep Curl',
+        description: 'Stand with a dumbbell in each hand, arms hanging at your sides with palms facing forward. Curl both dumbbells up toward your shoulders by bending your elbows, then lower with control.',
+        load: 'bilateral', weightPerDumbbell: 10, sets: 5, reps: 15,
+      },
+      {
+        id: 'pull-hammer-curl',
+        name: 'Hammer Curl',
+        description: 'Stand with a dumbbell in each hand, arms hanging at your sides with palms facing your body. Curl both dumbbells up toward your shoulders while keeping your palms facing inward, then lower with control.',
+        load: 'bilateral', weightPerDumbbell: 10, sets: 5, reps: 15,
+      },
+      {
+        id: 'pull-rear-delt-fly',
+        name: 'Rear Delt Fly',
+        description: "Hinge forward at the hips with a flat back, holding a dumbbell in each hand hanging below your shoulders with a slight bend in your elbows. Raise both arms out to the sides until they're roughly in line with your shoulders, then lower with control.",
+        load: 'bilateral', weightPerDumbbell: 5, sets: 5, reps: 15,
+      },
     ],
   },
   {
@@ -99,11 +153,36 @@ export const FREE_WEIGHT_ROUTINES: FreeWeightRoutine[] = [
     name: 'Legs',
     description: 'Quads, hamstrings, glutes, calves',
     exercises: [
-      { id: 'legs-suitcase-squat', name: 'Suitcase Squat', load: 'bilateral', weightPerDumbbell: 20, sets: 6, reps: 15 },
-      { id: 'legs-romanian-deadlift', name: 'Romanian Deadlift', load: 'bilateral', weightPerDumbbell: 15, sets: 6, reps: 15 },
-      { id: 'legs-reverse-lunge', name: 'Reverse Lunge', load: 'bilateral', weightPerDumbbell: 10, sets: 6, reps: 15 },
-      { id: 'legs-calf-raise', name: 'Calf Raise', load: 'bilateral', weightPerDumbbell: 5, sets: 6, reps: 15 },
-      { id: 'legs-glute-bridge', name: 'Glute Bridge', load: 'single', weightPerDumbbell: 15, sets: 6, reps: 15 },
+      {
+        id: 'legs-suitcase-squat',
+        name: 'Suitcase Squat',
+        description: 'Stand holding a dumbbell in each hand at your sides, like carrying suitcases, feet about shoulder-width apart. Bend your knees and hips to lower into a squat until your thighs are roughly parallel to the floor, then stand back up.',
+        load: 'bilateral', weightPerDumbbell: 20, sets: 6, reps: 15,
+      },
+      {
+        id: 'legs-romanian-deadlift',
+        name: 'Romanian Deadlift',
+        description: 'Stand holding a dumbbell in each hand in front of your thighs with knees slightly bent. Hinge at the hips and push them back, lowering the dumbbells along your legs until you feel a stretch in your hamstrings, then drive your hips forward to stand back up.',
+        load: 'bilateral', weightPerDumbbell: 15, sets: 6, reps: 15,
+      },
+      {
+        id: 'legs-reverse-lunge',
+        name: 'Reverse Lunge',
+        description: 'Stand holding a dumbbell in each hand at your sides, then step one leg backward and lower until both knees are bent around 90 degrees. Push through your front foot to return to standing, then repeat on the other side.',
+        load: 'bilateral', weightPerDumbbell: 10, sets: 6, reps: 15,
+      },
+      {
+        id: 'legs-calf-raise',
+        name: 'Calf Raise',
+        description: 'Stand holding a dumbbell in each hand at your sides with feet flat on the floor. Rise up onto the balls of your feet as high as you can, then lower your heels back down with control.',
+        load: 'bilateral', weightPerDumbbell: 5, sets: 6, reps: 15,
+      },
+      {
+        id: 'legs-glute-bridge',
+        name: 'Glute Bridge',
+        description: 'Lie on your back with knees bent and feet flat on the floor, holding one dumbbell across your hips with both hands. Drive through your heels to lift your hips toward the ceiling, squeezing your glutes, then lower back down with control.',
+        load: 'single', weightPerDumbbell: 15, sets: 6, reps: 15,
+      },
     ],
   },
 ]

--- a/src/lib/freeWeights.ts
+++ b/src/lib/freeWeights.ts
@@ -59,6 +59,16 @@ export function setVolume(exercise: FreeWeightExercise, repsCompleted: number): 
   return perRepVolume(exercise) * repsCompleted
 }
 
+/**
+ * Volume (lbs) for one completed set when both the reps AND the dumbbell
+ * weight actually used differ from the exercise's planned values (Phase 2
+ * per-set editing — e.g. you swapped to a lighter pair mid-set).
+ */
+export function customSetVolume(exercise: FreeWeightExercise, actualReps: number, actualWeight: number): number {
+  const multiplier = exercise.load === 'bilateral' ? 2 : 1
+  return actualWeight * multiplier * actualReps
+}
+
 export const FREE_WEIGHT_ROUTINES: FreeWeightRoutine[] = [
   {
     id: 'push',
@@ -100,6 +110,53 @@ export const FREE_WEIGHT_ROUTINES: FreeWeightRoutine[] = [
 
 export function getRoutine(id: string): FreeWeightRoutine | undefined {
   return FREE_WEIGHT_ROUTINES.find(r => r.id === id)
+}
+
+/** All dumbbell pairs available while traveling, lightest to heaviest. */
+export const WEIGHT_TIERS = [5, 10, 15, 20] as const
+
+/** Reps/set that triggers the "level up to the next dumbbell tier" prompt. */
+export const REP_CEILING = 20
+
+/** Reps/set to restart at after leveling up to a heavier dumbbell tier. */
+export const LEVEL_UP_RESET_REPS = 8
+
+/** The next heavier dumbbell tier, or null if already at the heaviest (20 lb). */
+export function nextWeightTier(current: number): 5 | 10 | 15 | 20 | null {
+  const index = WEIGHT_TIERS.indexOf(current as (typeof WEIGHT_TIERS)[number])
+  if (index === -1 || index === WEIGHT_TIERS.length - 1) return null
+  return WEIGHT_TIERS[index + 1]
+}
+
+/** A persisted override of one exercise's weight/reps (Phase 2 progression). */
+export interface FreeWeightProgressRow {
+  exerciseId: string
+  weightPerDumbbell: number
+  reps: number
+}
+
+/**
+ * Overlay DB progression rows onto the code-defined routines. Exercises
+ * with no matching row keep their code default (weight + reps); `sets`
+ * and `load` are never overridden — only weight and reps progress.
+ */
+export function mergeProgress(
+  routines: FreeWeightRoutine[],
+  progress: FreeWeightProgressRow[],
+): FreeWeightRoutine[] {
+  const byId = new Map(progress.map(p => [p.exerciseId, p]))
+  return routines.map(routine => ({
+    ...routine,
+    exercises: routine.exercises.map(exercise => {
+      const override = byId.get(exercise.id)
+      if (!override) return exercise
+      return {
+        ...exercise,
+        weightPerDumbbell: override.weightPerDumbbell as FreeWeightExercise['weightPerDumbbell'],
+        reps: override.reps,
+      }
+    }),
+  }))
 }
 
 /**


### PR DESCRIPTION
Phase 2 of Free Weights travel mode (Phase 1 shipped on `main`): persists per-exercise progression in the DB, lets a set's actual reps/weight be edited in the moment, flags sessions that fall below your current baseline, and exposes programming to MCP agents.

## What's in this PR
- **DB-backed progression**: new `FreeWeightProgress` table overrides the code-default reps/weight per exercise. Additive schema change, applied via the existing `prisma db push` build step.
- **Settings → Free Weights Progression**: `+`/`-` reps per exercise, and a "Level Up" prompt once an exercise hits 20 reps/set below the heaviest dumbbell tier (bumps weight, resets reps to 8).
- **Editable sets mid-workout**: tap the pencil icon on a set to correct actual reps/weight (defaults to planned; one tap still logs a set with planned values).
- **Baseline callout**: the session summary flags (non-blocking) any exercise that came in under your current baseline.
- **MCP**: `list_freeweight_progress` (read) and `set_freeweight_progress` (mutation, audited) so an agent can review/adjust programming like it can workouts/goals today.

## Testing done
- `tsc --noEmit` clean, `next build` succeeds, new routes/pages compile.
- Dev server smoke test: `/freeweights` 307s to `/login` and `/api/freeweights/progress` 401s when unauthenticated, matching existing routes.
- Not tested against a real Postgres instance (no DB credentials in the dev sandbox) — first real test will be against production data.

<details>
<summary>Design notes / decision log</summary>

Weight stays fixed to the dumbbells actually owned (5/10/15/20 lb pairs); only reps progress via Settings. The "level up" flow exists so reps don't have to climb forever on light weight — once you hit the ceiling, the app offers the next dumbbell size and restarts reps at a sane baseline.

The "don't regress" ask is handled as a visible nudge, not a hard gate: the active session always displays your *current* baseline (DB override merged over the code default) as each set's target, and the summary screen flags any exercise where completed reps fell short of that baseline.

Per-set weight edits during a workout are one-off (this set only) and do not change the Settings baseline — only the explicit Settings/MCP progression flow does that.

`FreeWeightProgress` is keyed by the same stable exercise slug introduced in Phase 1, so no data migration was needed beyond adding the table.
</details>

---
*Generated by Coder Agents on behalf of @carryologist.*