### PR TITLE
feat: allow combining multiple dumbbells for a single set

### DIFF
--- a/src/components/freeweights/ActiveSession.tsx
+++ b/src/components/freeweights/ActiveSession.tsx
@@ -9,6 +9,10 @@ export interface SetState {
   completed: boolean
   actualReps: number
   actualWeight: number
+  /** Dumbbell tiers combined to make up actualWeight, e.g. [10, 20] for a
+   * stacked 20lb + 10lb set. Defaults to a single-element array matching
+   * actualWeight for sets that haven't been edited. */
+  actualWeightTiers: number[]
 }
 
 interface ActiveSessionProps {
@@ -17,7 +21,13 @@ interface ActiveSessionProps {
   elapsedSeconds: number
   totalVolume: number
   onToggleSet: (exerciseId: string, setIndex: number) => void
-  onEditSet: (exerciseId: string, setIndex: number, actualReps: number, actualWeight: number) => void
+  onEditSet: (
+    exerciseId: string,
+    setIndex: number,
+    actualReps: number,
+    actualWeight: number,
+    actualWeightTiers: number[]
+  ) => void
   onFinish: () => void
   onCancel: () => void
 }
@@ -36,11 +46,20 @@ function SetEditor({
 }: {
   exercise: FreeWeightExercise
   set: SetState
-  onSave: (actualReps: number, actualWeight: number) => void
+  onSave: (actualReps: number, actualWeight: number, actualWeightTiers: number[]) => void
   onClose: () => void
 }) {
   const [reps, setReps] = useState(set.actualReps)
-  const [weight, setWeight] = useState(set.actualWeight)
+  const [tiers, setTiers] = useState<number[]>(
+    set.actualWeightTiers?.length ? set.actualWeightTiers : [set.actualWeight]
+  )
+  const combinedWeight = tiers.reduce((sum, t) => sum + t, 0)
+
+  const toggleTier = (tier: number) => {
+    setTiers(prev =>
+      prev.includes(tier) ? prev.filter(t => t !== tier) : [...prev, tier].sort((a, b) => a - b)
+    )
+  }
 
   return (
     <div className="mt-2 p-3 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
@@ -62,15 +81,16 @@ function SetEditor({
           </button>
         </div>
       </div>
-      <div className="flex items-center justify-between mb-3">
-        <label className="text-xs font-medium text-gray-600 dark:text-gray-300">Dumbbell used</label>
+      <div className="flex items-center justify-between mb-1">
+        <label className="text-xs font-medium text-gray-600 dark:text-gray-300">Dumbbell(s) used</label>
         <div className="flex gap-1">
           {WEIGHT_TIERS.map(tier => (
             <button
               key={tier}
-              onClick={() => setWeight(tier)}
+              onClick={() => toggleTier(tier)}
+              aria-pressed={tiers.includes(tier)}
               className={`px-2 py-1 rounded-md text-xs font-semibold border ${
-                weight === tier
+                tiers.includes(tier)
                   ? 'bg-primary-600 border-primary-600 text-white'
                   : 'bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300'
               }`}
@@ -80,13 +100,17 @@ function SetEditor({
           ))}
         </div>
       </div>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+        Combined: {combinedWeight} lb{tiers.length > 1 ? ` (${tiers.join(' + ')})` : ''}
+      </p>
       <div className="flex gap-2">
         <button
           onClick={() => {
-            onSave(reps, weight)
+            onSave(reps, combinedWeight, tiers)
             onClose()
           }}
-          className="flex-1 bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium py-1.5 rounded-md"
+          disabled={tiers.length === 0}
+          className="flex-1 bg-primary-600 hover:bg-primary-700 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium py-1.5 rounded-md"
         >
           Save
         </button>
@@ -214,11 +238,18 @@ export function ActiveSession({
                           <Pencil className="w-3.5 h-3.5" />
                         </button>
                       </div>
+                      {set.actualWeightTiers.length > 1 && (
+                        <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5 ml-1">
+                          {set.actualWeightTiers.join(' + ')} lb combined
+                        </p>
+                      )}
                       {isEditingThis && (
                         <SetEditor
                           exercise={exercise}
                           set={set}
-                          onSave={(actualReps, actualWeight) => onEditSet(exercise.id, setIndex, actualReps, actualWeight)}
+                          onSave={(actualReps, actualWeight, actualWeightTiers) =>
+                            onEditSet(exercise.id, setIndex, actualReps, actualWeight, actualWeightTiers)
+                          }
                           onClose={() => setEditing(null)}
                         />
                       )}

--- a/src/components/freeweights/FreeWeightsMode.tsx
+++ b/src/components/freeweights/FreeWeightsMode.tsx
@@ -30,6 +30,7 @@ function initialSets(routine: FreeWeightRoutine): Record<string, SetState[]> {
         completed: false,
         actualReps: ex.reps,
         actualWeight: ex.weightPerDumbbell,
+        actualWeightTiers: [ex.weightPerDumbbell],
       })),
     ])
   )
@@ -41,7 +42,19 @@ function loadPersistedSession(): PersistedSession | null {
     if (!raw) return null
     const parsed = JSON.parse(raw) as PersistedSession
     if (!parsed.routineId) return null
-    return parsed
+    // Back-compat: sessions persisted before multi-select weights shipped
+    // won't have actualWeightTiers on each set. Backfill from actualWeight
+    // so old in-progress sessions don't crash on resume.
+    const checked = Object.fromEntries(
+      Object.entries(parsed.checked ?? {}).map(([exerciseId, sets]) => [
+        exerciseId,
+        sets.map(s => ({
+          ...s,
+          actualWeightTiers: s.actualWeightTiers?.length ? s.actualWeightTiers : [s.actualWeight],
+        })),
+      ])
+    )
+    return { ...parsed, checked }
   } catch {
     return null
   }
@@ -163,11 +176,13 @@ export function FreeWeightsMode() {
   )
 
   const handleEditSet = useCallback(
-    (exerciseId: string, setIndex: number, actualReps: number, actualWeight: number) => {
+    (exerciseId: string, setIndex: number, actualReps: number, actualWeight: number, actualWeightTiers: number[]) => {
       setChecked(prev => {
         const next = {
           ...prev,
-          [exerciseId]: prev[exerciseId].map((s, i) => (i === setIndex ? { ...s, actualReps, actualWeight } : s)),
+          [exerciseId]: prev[exerciseId].map((s, i) =>
+            i === setIndex ? { ...s, actualReps, actualWeight, actualWeightTiers } : s
+          ),
         }
         if (routineId && startedAt !== null) {
           savePersistedSession({ routineId, startedAt, checked: next })


### PR DESCRIPTION
## What
In the free weights session's set editor (edit-set pencil icon), the "Dumbbell used" picker now supports **multi-select** instead of picking a single tier.

Example: for a Glute Bridge, you can now select both the 20 lb and 10 lb dumbbells to log a combined 30 lb set (e.g. stacking two dumbbells on your hips), instead of being limited to a single 5/10/15/20 lb tier.

## How
- `SetState` gains `actualWeightTiers: number[]` — the individual tiers combined to make up `actualWeight`.
- `SetEditor`'s weight buttons toggle in/out of the selection instead of replacing it; a "Combined: X lb (20 + 10)" line shows the sum live.
- `actualWeight` (used everywhere for volume math) is just `sum(actualWeightTiers)`, so `customSetVolume`, total volume, and workout logging all pick up the combined weight with no other changes.
- Sets edited with more than one tier show a small "20 + 10 lb combined" note under the set button.
- Backfills `actualWeightTiers` when restoring an in-progress session from localStorage that was saved before this change, so it won't crash on resume.

## Testing
- `npx tsc --noEmit` — clean
- `npx next build` — compiles and generates pages successfully (DB-dependent `prisma db push` step in `npm run build` can't run in this sandbox without real Postgres credentials, but the actual Next.js build passes)
