### PR TITLE
feat: allow stacked dumbbell weights in progression settings

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,7 +108,7 @@ model MonthlySummary {
 model FreeWeightProgress {
   id                String   @id @default(cuid())
   exerciseId        String   @unique // slug from src/lib/freeWeights.ts, e.g. "push-overhead-press"
-  weightPerDumbbell Int // 5 | 10 | 15 | 20
+  weightPerDumbbell Int // single tier (5/10/15/20) or a sum of stacked tiers, e.g. 30
   reps              Int
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt

--- a/src/app/api/freeweights/progress/route.ts
+++ b/src/app/api/freeweights/progress/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@/lib/prisma'
 import { requireAuth } from '@/lib/auth'
-import { WEIGHT_TIERS } from '@/lib/freeWeights'
+import { isValidCombinedWeight, combinedWeightOptions } from '@/lib/freeWeights'
 
 export const dynamic = 'force-dynamic'
 
@@ -34,9 +34,9 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: 'reps must be between 1 and 100' }, { status: 400 })
     }
     const parsedWeight = parseInt(weightPerDumbbell)
-    if (!WEIGHT_TIERS.includes(parsedWeight as (typeof WEIGHT_TIERS)[number])) {
+    if (isNaN(parsedWeight) || !isValidCombinedWeight(parsedWeight)) {
       return NextResponse.json(
-        { error: `weightPerDumbbell must be one of ${WEIGHT_TIERS.join(', ')}` },
+        { error: `weightPerDumbbell must be one of ${combinedWeightOptions().join(', ')} (single or stacked dumbbell tiers)` },
         { status: 400 }
       )
     }

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -6,7 +6,7 @@ import { runPelotonSync } from '@/lib/peloton-sync'
 import { runTonalSync } from '@/lib/tonal-sync'
 import { limitMcp, limitSync } from '@/lib/rate-limit'
 import { logAudit } from '@/lib/audit-log'
-import { FREE_WEIGHT_ROUTINES, WEIGHT_TIERS, mergeProgress } from '@/lib/freeWeights'
+import { FREE_WEIGHT_ROUTINES, combinedWeightOptions, isValidCombinedWeight, mergeProgress } from '@/lib/freeWeights'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300
@@ -225,13 +225,14 @@ const handler = createMcpHandler(
     server.tool(
       'set_freeweight_progress',
       'Update the current reps/set (and optionally dumbbell weight) baseline for one Free ' +
-        'Weights exercise. Weight must be one of the dumbbell pairs actually owned: 5, 10, 15, ' +
-        'or 20 lb. Use list_freeweight_progress first to find the exerciseId slug.',
+        'Weights exercise. Weight must be a single dumbbell pair (5, 10, 15, or 20 lb) or a sum ' +
+        'of stacked pairs (e.g. 30 for a 20 + 10 stack). Use list_freeweight_progress first to ' +
+        'find the exerciseId slug.',
       {
         exerciseId: z.string().min(1).describe('Exercise slug, e.g. "push-overhead-press".'),
         reps: z.number().int().min(1).max(100),
-        weightPerDumbbell: z.union([z.literal(5), z.literal(10), z.literal(15), z.literal(20)])
-          .describe('One of the dumbbell pairs available: 5, 10, 15, or 20 lb.'),
+        weightPerDumbbell: z.number().int().min(5).max(50)
+          .describe(`Single tier or stacked-tier sum. Valid values: ${combinedWeightOptions().join(', ')}.`),
       },
       async ({ exerciseId, reps, weightPerDumbbell }, extra) => {
         const known = FREE_WEIGHT_ROUTINES.some(r => r.exercises.some(ex => ex.id === exerciseId))
@@ -241,7 +242,7 @@ const handler = createMcpHandler(
             isError: true,
           }
         }
-        if (!WEIGHT_TIERS.includes(weightPerDumbbell)) {
+        if (!isValidCombinedWeight(weightPerDumbbell)) {
           return {
             content: [{ type: 'text', text: JSON.stringify({ error: 'invalid_weight', weightPerDumbbell }) }],
             isError: true,

--- a/src/components/freeweights/FreeWeightProgressSettings.tsx
+++ b/src/components/freeweights/FreeWeightProgressSettings.tsx
@@ -4,20 +4,28 @@ import { useEffect, useState } from 'react'
 import {
   FREE_WEIGHT_ROUTINES,
   WEIGHT_TIERS,
+  decomposeWeight,
   mergeProgress,
   type FreeWeightProgressRow,
   type FreeWeightRoutine,
 } from '@/lib/freeWeights'
 
 /**
- * Phase 2 progression control. Both reps/set and dumbbell weight (one of
- * the 5/10/15/20 lb tiers you own) are directly editable per exercise and
- * persist to the database, overriding the code defaults on every load.
+ * Phase 2 progression control. Reps/set are directly editable per exercise,
+ * and dumbbell weight is chosen by toggling one or more of the 5/10/15/20 lb
+ * tiers you own — stacking multiple selects a combined weight (e.g. 20 + 10 =
+ * 30 lb). Both persist to the database, overriding the code defaults on
+ * every load.
  */
 export function FreeWeightProgressSettings() {
   const [routines, setRoutines] = useState<FreeWeightRoutine[]>(FREE_WEIGHT_ROUTINES)
   const [loading, setLoading] = useState(true)
   const [pendingId, setPendingId] = useState<string | null>(null)
+  // Per-exercise dumbbell tier selection, kept separate from the persisted
+  // weightPerDumbbell sum since a combined weight can't always be uniquely
+  // decomposed back into tiers. Falls back to decomposeWeight() until the
+  // user has interacted with an exercise's tiers this session.
+  const [tierSelections, setTierSelections] = useState<Record<string, number[]>>({})
 
   useEffect(() => {
     let cancelled = false
@@ -51,13 +59,22 @@ export function FreeWeightProgressSettings() {
         prev.map(r => ({
           ...r,
           exercises: r.exercises.map(ex =>
-            ex.id === exerciseId ? { ...ex, reps, weightPerDumbbell: weightPerDumbbell as typeof ex.weightPerDumbbell } : ex
+            ex.id === exerciseId ? { ...ex, reps, weightPerDumbbell } : ex
           ),
         }))
       )
     } finally {
       setPendingId(null)
     }
+  }
+
+  const toggleTier = (exercise: FreeWeightRoutine['exercises'][number], tier: number) => {
+    const current = tierSelections[exercise.id] ?? decomposeWeight(exercise.weightPerDumbbell)
+    const next = current.includes(tier) ? current.filter(t => t !== tier) : [...current, tier].sort((a, b) => a - b)
+    if (next.length === 0) return // keep at least one dumbbell selected
+    setTierSelections(prev => ({ ...prev, [exercise.id]: next }))
+    const combinedWeight = next.reduce((sum, t) => sum + t, 0)
+    patch(exercise.id, exercise.reps, combinedWeight)
   }
 
   if (loading) {
@@ -76,13 +93,14 @@ export function FreeWeightProgressSettings() {
           <div className="space-y-2">
             {routine.exercises.map(exercise => {
               const disabled = pendingId === exercise.id
+              const selectedTiers = tierSelections[exercise.id] ?? decomposeWeight(exercise.weightPerDumbbell)
 
               return (
                 <div key={exercise.id} className="flex items-center justify-between gap-2">
                   <div className="min-w-0">
                     <p className="text-sm text-gray-800 dark:text-gray-200 truncate">{exercise.name}</p>
                     <p className="text-xs text-gray-500 dark:text-gray-400">
-                      {exercise.weightPerDumbbell} lb · {exercise.reps} reps/set
+                      {exercise.weightPerDumbbell} lb{selectedTiers.length > 1 ? ` (${selectedTiers.join(' + ')})` : ''} · {exercise.reps} reps/set
                     </p>
                   </div>
                   <div className="flex items-center gap-3 shrink-0">
@@ -91,9 +109,10 @@ export function FreeWeightProgressSettings() {
                         <button
                           key={tier}
                           disabled={disabled}
-                          onClick={() => patch(exercise.id, exercise.reps, tier)}
+                          onClick={() => toggleTier(exercise, tier)}
+                          aria-pressed={selectedTiers.includes(tier)}
                           className={`px-2 py-1 rounded-md text-xs font-semibold border disabled:opacity-40 ${
-                            exercise.weightPerDumbbell === tier
+                            selectedTiers.includes(tier)
                               ? 'bg-primary-600 border-primary-600 text-white'
                               : 'bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300'
                           }`}

--- a/src/lib/freeWeights.ts
+++ b/src/lib/freeWeights.ts
@@ -29,8 +29,10 @@ export interface FreeWeightExercise {
    * - single: one dumbbell held with both hands (e.g. goblet squat). Volume/rep = weightPerDumbbell.
    */
   load: LoadType
-  /** One of the dumbbell pairs you're traveling with: 5, 10, 15, or 20 lb. */
-  weightPerDumbbell: 5 | 10 | 15 | 20
+  /** Weight actually loaded per side: one dumbbell pair (5/10/15/20 lb) or
+   * several stacked together (e.g. 20 + 10 = 30). Always a sum of one or
+   * more entries from WEIGHT_TIERS — see isValidCombinedWeight. */
+  weightPerDumbbell: number
   sets: number
   reps: number
 }
@@ -194,6 +196,52 @@ export function getRoutine(id: string): FreeWeightRoutine | undefined {
 /** All dumbbell pairs available while traveling, lightest to heaviest. */
 export const WEIGHT_TIERS = [5, 10, 15, 20] as const
 
+/** Every achievable combined weight from stacking one or more dumbbell
+ * pairs together (each pair used at most once), lightest to heaviest. */
+export function combinedWeightOptions(tiers: readonly number[] = WEIGHT_TIERS): number[] {
+  const sums = new Set<number>()
+  const n = tiers.length
+  for (let mask = 1; mask < 1 << n; mask++) {
+    let sum = 0
+    for (let i = 0; i < n; i++) {
+      if (mask & (1 << i)) sum += tiers[i]
+    }
+    sums.add(sum)
+  }
+  return Array.from(sums).sort((a, b) => a - b)
+}
+
+/** Whether `weight` can be made by stacking one or more dumbbell pairs. */
+export function isValidCombinedWeight(weight: number, tiers: readonly number[] = WEIGHT_TIERS): boolean {
+  return combinedWeightOptions(tiers).includes(weight)
+}
+
+/**
+ * Best-effort breakdown of a combined weight into the dumbbell tiers that
+ * make it up, e.g. 30 -> [10, 20]. Prefers the fewest tiers (so an exact
+ * tier match, e.g. 20 -> [20], always wins over a multi-tier combo that
+ * happens to sum to the same value). Falls back to [weight] if no
+ * combination matches (shouldn't happen for validated values).
+ */
+export function decomposeWeight(weight: number, tiers: readonly number[] = WEIGHT_TIERS): number[] {
+  const n = tiers.length
+  let best: number[] | null = null
+  for (let mask = 1; mask < 1 << n; mask++) {
+    let sum = 0
+    const combo: number[] = []
+    for (let i = 0; i < n; i++) {
+      if (mask & (1 << i)) {
+        sum += tiers[i]
+        combo.push(tiers[i])
+      }
+    }
+    if (sum === weight && (!best || combo.length < best.length)) {
+      best = combo
+    }
+  }
+  return (best ?? [weight]).sort((a, b) => a - b)
+}
+
 /** A persisted override of one exercise's weight/reps (Phase 2 progression). */
 export interface FreeWeightProgressRow {
   exerciseId: string
@@ -218,7 +266,7 @@ export function mergeProgress(
       if (!override) return exercise
       return {
         ...exercise,
-        weightPerDumbbell: override.weightPerDumbbell as FreeWeightExercise['weightPerDumbbell'],
+        weightPerDumbbell: override.weightPerDumbbell,
         reps: override.reps,
       }
     }),


### PR DESCRIPTION
Extends the multi-select weight feature (from the in-session set editor) to the Free Weight Progress settings page. You can now toggle multiple dumbbell tiers per exercise baseline (e.g. 20 + 10 = 30 lb), and the REST + MCP validation now accepts any combined-tier sum instead of only exact single tiers.

- `src/lib/freeWeights.ts`: added `combinedWeightOptions`, `isValidCombinedWeight`, `decomposeWeight` helpers; widened `weightPerDumbbell` to `number`.
- `FreeWeightProgressSettings.tsx`: tier buttons are now multi-select, combined weight shown next to each exercise.
- API + MCP `set_freeweight_progress`: validation now allows any stacked-tier sum.

Verified with `tsc --noEmit` and `next build` (both clean; pre-existing `next lint` config issue unrelated).