### PR TITLE
feat: track body weight via direct Renpho integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,13 @@ TONAL_EMAIL=""
 TONAL_PASSWORD=""
 
 # -----------------------------------------------------------------------------
+# Renpho Integration
+# -----------------------------------------------------------------------------
+# Renpho account credentials for body weight/composition sync (src/lib/renpho.ts)
+RENPHO_EMAIL=""
+RENPHO_PASSWORD=""
+
+# -----------------------------------------------------------------------------
 # App URL (optional)
 # -----------------------------------------------------------------------------
 # Explicit base URL added to the MCP CORS allow-list (src/app/api/mcp/[transport]/route.ts)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,6 +61,47 @@ model TonalCredential {
   @@map("tonal_credentials")
 }
 
+model RenphoCredential {
+  id         String   @id @default(cuid())
+  userId     String   @unique // Renpho account user id
+  token      String   @db.Text // Renpho session token (encrypted at rest)
+  obtainedAt DateTime @default(now()) // when `token` was issued; used to decide when to re-login
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@map("renpho_credentials")
+}
+
+// Body weight / composition history, synced from Renpho smart scale readings.
+// One row per calendar day: when a day has multiple scale readings (e.g.
+// weighing in more than once), the lowest-weight reading for that day wins —
+// see pickDailyReading() in src/lib/renpho-sync.ts.
+model BodyMeasurement {
+  id                 String   @id @default(cuid())
+  date               DateTime @unique // calendar date (local midnight), one row per day
+  weightLbs          Float
+  bmi                Float?
+  bodyFatPct         Float?
+  waterPct           Float?
+  musclePct          Float?
+  boneMassPct        Float?
+  bmr                Float? // kcal/day
+  visceralFatLevel   Float?
+  subcutaneousFatPct Float?
+  proteinPct         Float?
+  bodyAgeYears       Float?
+  leanBodyMassLbs    Float? // Renpho "sinew"
+  fatFreeWeightLbs   Float?
+  heartRateBpm       Float?
+  source             String   @default("Renpho")
+  renphoRecordId     String? // raw record id of the winning reading, for traceability
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  @@index([date])
+  @@map("body_measurements")
+}
+
 // Goal tracking for quarterly and annual targets
 model Goal {
   id   String @id @default(cuid())

--- a/src/app/api/body-measurements/route.ts
+++ b/src/app/api/body-measurements/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { requireAuth } from '@/lib/auth'
+
+// GET — body measurement history, optionally filtered by date range.
+// Query params: from, to (ISO date strings, inclusive).
+export async function GET(request: Request) {
+  const authResult = await requireAuth(request)
+  if (authResult instanceof NextResponse) return authResult
+
+  try {
+    const url = new URL(request.url)
+    const from = url.searchParams.get('from')
+    const to = url.searchParams.get('to')
+
+    const where: { date?: { gte?: Date; lte?: Date } } = {}
+    if (from || to) {
+      where.date = {}
+      if (from) where.date.gte = new Date(from)
+      if (to) where.date.lte = new Date(to)
+    }
+
+    const measurements = await prisma.bodyMeasurement.findMany({
+      where,
+      orderBy: { date: 'asc' },
+    })
+
+    return NextResponse.json(measurements)
+  } catch (error) {
+    console.error('Body measurements fetch error:', error instanceof Error ? error.message : 'unknown')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/renpho/auth/route.ts
+++ b/src/app/api/renpho/auth/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth'
+import { authenticateAndStoreRenphoCredential, RenphoSyncError } from '@/lib/renpho-sync'
+
+export async function POST(request: Request) {
+  const authResult = await requireAuth(request)
+  if (authResult instanceof NextResponse) return authResult
+
+  try {
+    console.log('🔐 Authenticating with Renpho...')
+    const cred = await authenticateAndStoreRenphoCredential()
+    return NextResponse.json({ connected: true, userId: cred.userId })
+  } catch (error) {
+    if (error instanceof RenphoSyncError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    console.error('💥 Renpho auth error:', error instanceof Error ? error.message : error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/renpho/sync/route.ts
+++ b/src/app/api/renpho/sync/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { requireAuth } from '@/lib/auth'
+import { runRenphoSync, ensureFreshRenphoToken, RenphoSyncError } from '@/lib/renpho-sync'
+import { logAudit } from '@/lib/audit-log'
+
+// GET — connection status (auto-refreshes token if stale)
+export async function GET(request: Request) {
+  const authResult = await requireAuth(request)
+  if (authResult instanceof NextResponse) return authResult
+
+  try {
+    const cred = await prisma.renphoCredential.findFirst()
+    if (!cred) return NextResponse.json({ connected: false })
+
+    try {
+      await ensureFreshRenphoToken(cred)
+      return NextResponse.json({ connected: true, userId: cred.userId })
+    } catch {
+      return NextResponse.json({ connected: false, reason: 'token_expired' })
+    }
+  } catch (error) {
+    console.error('Renpho status check error:', error instanceof Error ? error.message : 'unknown')
+    return NextResponse.json({ connected: false }, { status: 500 })
+  }
+}
+
+// POST — sync body measurements from Renpho
+export async function POST(req: Request) {
+  const authResult = await requireAuth(req)
+  if (authResult instanceof NextResponse) return authResult
+
+  try {
+    const result = await runRenphoSync()
+    await logAudit(req, authResult, 'renpho.sync', { result })
+    return NextResponse.json(result)
+  } catch (error) {
+    if (error instanceof RenphoSyncError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    console.error('Renpho sync error:', message)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// DELETE — disconnect Renpho
+export async function DELETE(request: Request) {
+  const authResult = await requireAuth(request)
+  if (authResult instanceof NextResponse) return authResult
+
+  try {
+    const cred = await prisma.renphoCredential.findFirst()
+    if (cred) await prisma.renphoCredential.delete({ where: { id: cred.id } })
+    await logAudit(request, authResult, 'renpho.disconnect', {})
+    return NextResponse.json({ disconnected: true })
+  } catch (error) {
+    console.error('Renpho disconnect error:', error instanceof Error ? error.message : 'unknown')
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/health/page.tsx
+++ b/src/app/health/page.tsx
@@ -1,0 +1,27 @@
+import { HealthDashboard } from '@/components/HealthDashboard'
+import { NavTabs } from '@/components/NavTabs'
+import { ThemeToggle } from '@/components/ThemeToggle'
+import { AuthHeader } from '@/components/AuthHeader'
+
+// See src/app/page.tsx for why this is force-dynamic: middleware-based auth
+// redirects don't run against a prerendered static shell.
+export const dynamic = 'force-dynamic'
+
+export default function HealthPage() {
+  return (
+    <main className="min-h-screen bg-gray-50 dark:bg-gray-950">
+      <header className="bg-white dark:bg-gray-900 shadow-sm border-b border-gray-200 dark:border-gray-700 sticky top-0 z-50">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center justify-between gap-4">
+          <NavTabs />
+          <div className="flex items-center gap-2 shrink-0">
+            <ThemeToggle />
+            <div className="hidden sm:block">
+              <AuthHeader />
+            </div>
+          </div>
+        </div>
+      </header>
+      <HealthDashboard />
+    </main>
+  )
+}

--- a/src/components/HealthDashboard.tsx
+++ b/src/components/HealthDashboard.tsx
@@ -1,0 +1,216 @@
+'use client'
+
+import React, { useState, useEffect, useCallback } from 'react'
+import { RefreshCw, Scale, TrendingDown, TrendingUp, Minus, ChevronDown, ChevronUp } from 'lucide-react'
+import { format } from 'date-fns'
+import { WeightProgressChart } from './WeightProgressChart'
+import { BodyMeasurement, BodyMeasurementApiRecord } from '@/types/health'
+
+function parseMeasurement(raw: BodyMeasurementApiRecord): BodyMeasurement {
+  return { ...raw, date: new Date(raw.date) }
+}
+
+interface ChangeStatProps {
+  label: string
+  current: number | null
+  previous: number | null
+}
+
+function ChangeStat({ label, current, previous }: ChangeStatProps) {
+  const delta = current != null && previous != null ? current - previous : null
+  const Icon = delta == null || Math.abs(delta) < 0.1 ? Minus : delta > 0 ? TrendingUp : TrendingDown
+  const color =
+    delta == null || Math.abs(delta) < 0.1
+      ? 'text-gray-500 dark:text-gray-400'
+      : delta > 0
+        ? 'text-red-600 dark:text-red-400'
+        : 'text-green-600 dark:text-green-400'
+
+  return (
+    <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3 sm:p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <Icon className={`w-4 h-4 ${color}`} />
+        <span className="text-sm text-gray-600 dark:text-gray-400">{label}</span>
+      </div>
+      <p className={`text-2xl font-bold ${delta == null ? 'text-gray-900 dark:text-gray-100' : color}`}>
+        {delta == null ? '—' : `${delta > 0 ? '+' : ''}${delta.toFixed(1)} lbs`}
+      </p>
+    </div>
+  )
+}
+
+export function HealthDashboard() {
+  const [measurements, setMeasurements] = useState<BodyMeasurement[]>([])
+  const [loading, setLoading] = useState(true)
+  const [syncing, setSyncing] = useState(false)
+  const [syncError, setSyncError] = useState<string | null>(null)
+  const [syncSuccess, setSyncSuccess] = useState<string | null>(null)
+  const [showTable, setShowTable] = useState(false)
+
+  const loadData = useCallback(async () => {
+    try {
+      const res = await fetch('/api/body-measurements')
+      if (!res.ok) throw new Error(`Failed to load: ${res.status}`)
+      const data: BodyMeasurementApiRecord[] = await res.json()
+      setMeasurements(data.map(parseMeasurement))
+    } catch (error) {
+      console.error('Failed to load body measurements:', error)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
+
+  const handleSync = async () => {
+    setSyncing(true)
+    setSyncError(null)
+    try {
+      const statusRes = await fetch('/api/renpho/sync')
+      const statusData = await statusRes.json()
+      if (!statusData.connected) {
+        const authRes = await fetch('/api/renpho/auth', { method: 'POST' })
+        if (!authRes.ok) {
+          const err = await authRes.json().catch(() => ({ error: 'Auth failed' }))
+          setSyncError(`Renpho auth failed: ${err.error || authRes.status}`)
+          return
+        }
+      }
+      const res = await fetch('/api/renpho/sync', { method: 'POST' })
+      const data = await res.json()
+      if (res.ok) {
+        if (data.synced > 0 || data.updated > 0) await loadData()
+        const parts: string[] = []
+        if (data.synced > 0) parts.push(`${data.synced} new`)
+        if (data.updated > 0) parts.push(`${data.updated} updated`)
+        if (data.skipped > 0) parts.push(`${data.skipped} already synced`)
+        setSyncSuccess(`Renpho sync: ${parts.length > 0 ? parts.join(', ') : 'up to date'}`)
+        setTimeout(() => setSyncSuccess(null), 6000)
+      } else {
+        setSyncError(`Renpho sync failed: ${data.error || res.status}`)
+      }
+    } catch (error) {
+      setSyncError(`Renpho sync failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    } finally {
+      setSyncing(false)
+    }
+  }
+
+  const sorted = [...measurements].sort((a, b) => b.date.getTime() - a.date.getTime())
+  const latest = sorted[0] ?? null
+  const findAsOf = (daysAgo: number) => {
+    const target = latest ? latest.date.getTime() - daysAgo * 86400000 : 0
+    // Closest reading at or before the target date.
+    return sorted.find(m => m.date.getTime() <= target)?.weightLbs ?? null
+  }
+
+  if (loading) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <p className="text-gray-500 dark:text-gray-400">Loading…</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Health</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400">Weight and body composition trends, synced from Renpho</p>
+        </div>
+        <div className="flex flex-col items-end gap-1">
+          <button
+            onClick={handleSync}
+            disabled={syncing}
+            className="bg-primary-500 hover:bg-primary-600 disabled:opacity-50 text-white px-3 py-1.5 rounded-lg font-medium transition-colors flex items-center gap-1.5 shadow-sm text-sm"
+          >
+            <RefreshCw className={`w-4 h-4 ${syncing ? 'animate-spin' : ''}`} />
+            <span>{syncing ? 'Syncing…' : 'Sync Renpho'}</span>
+          </button>
+          {syncError && <p className="text-xs text-red-600 dark:text-red-400 max-w-xs text-right">{syncError}</p>}
+          {syncSuccess && <p className="text-xs text-green-600 dark:text-green-400 max-w-xs text-right">{syncSuccess}</p>}
+        </div>
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-3 sm:p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <Scale className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+            <span className="text-sm text-gray-600 dark:text-gray-400">Current Weight</span>
+          </div>
+          <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            {latest ? `${latest.weightLbs.toFixed(1)} lbs` : '—'}
+          </p>
+          {latest && (
+            <p className="text-xs text-gray-500 dark:text-gray-500 mt-1">as of {format(latest.date, 'MMM d, yyyy')}</p>
+          )}
+        </div>
+        <ChangeStat label="7-Day Change" current={latest?.weightLbs ?? null} previous={findAsOf(7)} />
+        <ChangeStat label="30-Day Change" current={latest?.weightLbs ?? null} previous={findAsOf(30)} />
+        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-3 sm:p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <Scale className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+            <span className="text-sm text-gray-600 dark:text-gray-400">Body Fat</span>
+          </div>
+          <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            {latest?.bodyFatPct != null ? `${latest.bodyFatPct.toFixed(1)}%` : '—'}
+          </p>
+        </div>
+      </div>
+
+      <WeightProgressChart measurements={measurements} />
+
+      {/* Raw history table */}
+      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+        <button
+          onClick={() => setShowTable(v => !v)}
+          className="w-full flex items-center justify-between p-4 text-left"
+        >
+          <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+            History ({measurements.length} {measurements.length === 1 ? 'entry' : 'entries'})
+          </span>
+          {showTable ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+        </button>
+        {showTable && (
+          <div className="overflow-x-auto border-t border-gray-200 dark:border-gray-700">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500 dark:text-gray-400">
+                  <th className="px-4 py-2 font-medium">Date</th>
+                  <th className="px-4 py-2 font-medium">Weight</th>
+                  <th className="px-4 py-2 font-medium">Body Fat</th>
+                  <th className="px-4 py-2 font-medium">Muscle</th>
+                  <th className="px-4 py-2 font-medium">BMI</th>
+                  <th className="px-4 py-2 font-medium">Lean Mass</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map(m => (
+                  <tr key={m.id} className="border-t border-gray-100 dark:border-gray-800">
+                    <td className="px-4 py-2 text-gray-900 dark:text-gray-100">{format(m.date, 'MMM d, yyyy')}</td>
+                    <td className="px-4 py-2 text-gray-900 dark:text-gray-100">{m.weightLbs.toFixed(1)} lbs</td>
+                    <td className="px-4 py-2 text-gray-600 dark:text-gray-400">{m.bodyFatPct != null ? `${m.bodyFatPct.toFixed(1)}%` : '—'}</td>
+                    <td className="px-4 py-2 text-gray-600 dark:text-gray-400">{m.musclePct != null ? `${m.musclePct.toFixed(1)}%` : '—'}</td>
+                    <td className="px-4 py-2 text-gray-600 dark:text-gray-400">{m.bmi != null ? m.bmi.toFixed(1) : '—'}</td>
+                    <td className="px-4 py-2 text-gray-600 dark:text-gray-400">{m.leanBodyMassLbs != null ? `${m.leanBodyMassLbs.toFixed(1)} lbs` : '—'}</td>
+                  </tr>
+                ))}
+                {sorted.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-6 text-center text-gray-500 dark:text-gray-400">
+                      No entries yet.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/NavTabs.tsx
+++ b/src/components/NavTabs.tsx
@@ -2,11 +2,12 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { LayoutDashboard, Dumbbell } from 'lucide-react'
+import { LayoutDashboard, Dumbbell, HeartPulse } from 'lucide-react'
 
 const TABS = [
   { href: '/', label: 'Dashboard', icon: LayoutDashboard },
   { href: '/freeweights', label: 'Free Weights', icon: Dumbbell },
+  { href: '/health', label: 'Health', icon: HeartPulse },
 ]
 
 export function NavTabs() {

--- a/src/components/WeightProgressChart.tsx
+++ b/src/components/WeightProgressChart.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import React, { useMemo, useState } from 'react'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
+import { format, subDays, subMonths, isAfter } from 'date-fns'
+import { BodyMeasurement } from '@/types/health'
+
+type RangeMode = '30d' | '90d' | '6m' | '1y' | 'all'
+
+const RANGE_OPTIONS: { value: RangeMode; label: string }[] = [
+  { value: '30d', label: '30 Days' },
+  { value: '90d', label: '90 Days' },
+  { value: '6m', label: '6 Months' },
+  { value: '1y', label: '1 Year' },
+  { value: 'all', label: 'All Time' },
+]
+
+const SECONDARY_METRICS: { key: keyof BodyMeasurement; label: string; color: string }[] = [
+  { key: 'bodyFatPct', label: 'Body Fat %', color: '#f97316' },
+  { key: 'musclePct', label: 'Muscle %', color: '#8b5cf6' },
+  { key: 'leanBodyMassLbs', label: 'Lean Mass (lbs)', color: '#10b981' },
+]
+
+interface WeightProgressChartProps {
+  measurements: BodyMeasurement[]
+}
+
+export function WeightProgressChart({ measurements }: WeightProgressChartProps) {
+  const [range, setRange] = useState<RangeMode>('90d')
+  const [secondaryMetric, setSecondaryMetric] = useState<keyof BodyMeasurement | 'none'>('none')
+
+  const filtered = useMemo(() => {
+    if (range === 'all') return measurements
+    const now = new Date()
+    const cutoff =
+      range === '30d' ? subDays(now, 30) :
+      range === '90d' ? subDays(now, 90) :
+      range === '6m' ? subMonths(now, 6) :
+      subMonths(now, 12)
+    return measurements.filter(m => isAfter(m.date, cutoff))
+  }, [measurements, range])
+
+  const chartData = useMemo(() => {
+    return filtered.map(m => ({
+      dateLabel: format(m.date, 'MMM d'),
+      weight: Math.round(m.weightLbs * 10) / 10,
+      secondary:
+        secondaryMetric !== 'none' && typeof m[secondaryMetric] === 'number'
+          ? Math.round((m[secondaryMetric] as number) * 10) / 10
+          : undefined,
+    }))
+  }, [filtered, secondaryMetric])
+
+  if (measurements.length === 0) {
+    return (
+      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+        <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-12">
+          No weight data yet. Connect Renpho and sync to see your trend.
+        </p>
+      </div>
+    )
+  }
+
+  const activeSecondary = SECONDARY_METRICS.find(m => m.key === secondaryMetric)
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Weight Trend</h2>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1">
+            {RANGE_OPTIONS.map(opt => (
+              <button
+                key={opt.value}
+                onClick={() => setRange(opt.value)}
+                className={`px-2.5 py-1 rounded-md text-xs font-medium transition-colors ${
+                  range === opt.value
+                    ? 'bg-white dark:bg-gray-700 shadow-sm text-primary-600 dark:text-primary-400'
+                    : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+          <select
+            value={secondaryMetric}
+            onChange={e => setSecondaryMetric(e.target.value as keyof BodyMeasurement | 'none')}
+            className="text-xs font-medium bg-gray-100 dark:bg-gray-800 border-0 rounded-md px-2 py-1.5 text-gray-700 dark:text-gray-300"
+          >
+            <option value="none">Weight only</option>
+            {SECONDARY_METRICS.map(m => (
+              <option key={m.key} value={m.key}>+ {m.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="h-72">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+            <XAxis dataKey="dateLabel" tick={{ fontSize: 12 }} minTickGap={30} />
+            <YAxis yAxisId="weight" domain={['auto', 'auto']} tick={{ fontSize: 12 }} width={40} />
+            {activeSecondary && (
+              <YAxis yAxisId="secondary" orientation="right" domain={['auto', 'auto']} tick={{ fontSize: 12 }} width={40} />
+            )}
+            <Tooltip
+              contentStyle={{ fontSize: 13, borderRadius: 8 }}
+              formatter={(value: number, name: string) => [value, name]}
+            />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            <Line
+              yAxisId="weight"
+              type="monotone"
+              dataKey="weight"
+              name="Weight (lbs)"
+              stroke="#2563eb"
+              strokeWidth={2}
+              dot={false}
+              connectNulls
+            />
+            {activeSecondary && (
+              <Line
+                yAxisId="secondary"
+                type="monotone"
+                dataKey="secondary"
+                name={activeSecondary.label}
+                stroke={activeSecondary.color}
+                strokeWidth={2}
+                dot={false}
+                connectNulls
+              />
+            )}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/renpho-sync.ts
+++ b/src/lib/renpho-sync.ts
@@ -1,0 +1,139 @@
+/**
+ * Renpho sync — orchestration mirroring src/lib/tonal-sync.ts. Logs in
+ * (using cached token when fresh enough), fetches the full measurement
+ * history, collapses same-day readings to the lowest weight, and
+ * upserts one BodyMeasurement row per day.
+ */
+import prisma from '@/lib/prisma'
+import {
+  loginToRenpho,
+  fetchAllRenphoMeasurements,
+  mapRenphoMeasurement,
+  pickDailyReadings,
+} from '@/lib/renpho'
+import type { RenphoCredential } from '@prisma/client'
+import { encryptSecret, decryptSecret } from '@/lib/crypto'
+
+export interface RenphoSyncResult {
+  synced: number
+  updated: number
+  skipped: number
+  total: number
+}
+
+export class RenphoSyncError extends Error {
+  status: number
+  constructor(message: string, status: number) {
+    super(message)
+    this.status = status
+  }
+}
+
+// Renpho's login response carries no documented token lifetime. Re-login
+// proactively after this window rather than waiting for a request to fail.
+const TOKEN_MAX_AGE_MS = 12 * 60 * 60 * 1000 // 12 hours
+
+/** Log in and store/refresh the cached credential. Requires RENPHO_EMAIL/RENPHO_PASSWORD env vars. */
+export async function authenticateAndStoreRenphoCredential(): Promise<RenphoCredential> {
+  const email = process.env.RENPHO_EMAIL?.trim()
+  const password = process.env.RENPHO_PASSWORD?.trim()
+  if (!email || !password) {
+    throw new RenphoSyncError('RENPHO_EMAIL and RENPHO_PASSWORD env vars are required', 400)
+  }
+
+  const { token, userId } = await loginToRenpho(email, password)
+
+  return prisma.renphoCredential.upsert({
+    where: { userId },
+    update: { token: encryptSecret(token), obtainedAt: new Date() },
+    create: { userId, token: encryptSecret(token), obtainedAt: new Date() },
+  })
+}
+
+async function getCredentialOrFail(): Promise<RenphoCredential> {
+  const cred = await prisma.renphoCredential.findFirst()
+  if (!cred) {
+    throw new RenphoSyncError('No Renpho credentials found. POST /api/renpho/auth first.', 401)
+  }
+  return cred
+}
+
+/** Re-authenticate if the cached token is stale; otherwise return as-is. */
+export async function ensureFreshRenphoToken(cred: RenphoCredential): Promise<RenphoCredential> {
+  const age = Date.now() - cred.obtainedAt.getTime()
+  if (age < TOKEN_MAX_AGE_MS) return cred
+  return authenticateAndStoreRenphoCredential()
+}
+
+/**
+ * Run a Renpho sync: fetch full measurement history, collapse to one
+ * lowest-weight reading per day, upsert into BodyMeasurement by date.
+ */
+export async function runRenphoSync(): Promise<RenphoSyncResult> {
+  let cred = await getCredentialOrFail()
+  cred = await ensureFreshRenphoToken(cred)
+
+  let synced = 0
+  let updated = 0
+  let skipped = 0
+
+  async function withReauthRetry<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      cred = await authenticateAndStoreRenphoCredential()
+      try {
+        return await fn()
+      } catch (retryErr) {
+        const retryMessage = retryErr instanceof Error ? retryErr.message : String(retryErr)
+        throw new RenphoSyncError(`Renpho sync failed after re-auth: ${retryMessage} (initial: ${message})`, 401)
+      }
+    }
+  }
+
+  const rawMeasurements = await withReauthRetry(() =>
+    fetchAllRenphoMeasurements(decryptSecret(cred.token), cred.userId),
+  )
+  const total = rawMeasurements.length
+
+  const mapped = rawMeasurements
+    .map(mapRenphoMeasurement)
+    .filter((m): m is NonNullable<typeof m> => m != null)
+  const dailyReadings = pickDailyReadings(mapped)
+
+  for (const reading of dailyReadings) {
+    const existing = await prisma.bodyMeasurement.findUnique({ where: { date: reading.date } })
+
+    const data = {
+      weightLbs: reading.weightLbs,
+      bmi: reading.bmi,
+      bodyFatPct: reading.bodyFatPct,
+      waterPct: reading.waterPct,
+      musclePct: reading.musclePct,
+      boneMassPct: reading.boneMassPct,
+      bmr: reading.bmr,
+      visceralFatLevel: reading.visceralFatLevel,
+      subcutaneousFatPct: reading.subcutaneousFatPct,
+      proteinPct: reading.proteinPct,
+      bodyAgeYears: reading.bodyAgeYears,
+      leanBodyMassLbs: reading.leanBodyMassLbs,
+      fatFreeWeightLbs: reading.fatFreeWeightLbs,
+      heartRateBpm: reading.heartRateBpm,
+      renphoRecordId: reading.renphoRecordId,
+    }
+
+    if (!existing) {
+      await prisma.bodyMeasurement.create({ data: { date: reading.date, source: 'Renpho', ...data } })
+      synced++
+    } else if (existing.renphoRecordId !== reading.renphoRecordId) {
+      // Same day, different (or newly-discovered lower) reading than what's stored.
+      await prisma.bodyMeasurement.update({ where: { id: existing.id }, data })
+      updated++
+    } else {
+      skipped++
+    }
+  }
+
+  return { synced, updated, skipped, total }
+}

--- a/src/lib/renpho.ts
+++ b/src/lib/renpho.ts
@@ -1,0 +1,321 @@
+// Renpho API client (reverse-engineered, no official docs)
+// Auth via a proprietary AES-128-ECB encrypted JSON envelope over HTTPS —
+// every request body is `{ encryptData: base64(AES-128-ECB(JSON)) }` and
+// every response's `data` field is decrypted the same way.
+// Reference: danvaneijck/renpho-api (Python), itself based on
+// forkerer/RenphoGarminSync-CLI's reverse-engineering of the Renpho app.
+
+import { createCipheriv, createDecipheriv } from 'crypto'
+
+const API_BASE_URL = 'https://cloud.renpho.com'
+// Renpho's own hardcoded AES-128 key, baked into their mobile app — not a
+// secret we manage, just a fixed transport-obfuscation key.
+const ENCRYPTION_KEY = 'ed*wijdi$h6fe3ew'
+const APP_VERSION = '6.6.0'
+const PLATFORM = 'android'
+const SYSTEM_VERSION = '11'
+
+const ENDPOINTS = {
+  login: 'renpho-aggregation/user/login',
+  deviceInfo: 'renpho-aggregation/device/count',
+  measurements: 'RenphoHealth/scale/queryAllMeasureDataList',
+  bodyCompositionMeasurements: 'RenphoHealth/scale/queryBodyCompositionMeasureData',
+} as const
+
+const BODY_WEIGHT_SCALES = [
+  '01', '02', '03', '04', '05', '06', '07', '08', '09', '0A',
+  '0B', '0C', '0D', '0E', '0F', '10', '11', '12', '13', '14',
+]
+
+const SUCCESS_CODES = new Set(['0', '101', '200', '20000'])
+
+// --- AES-128-ECB + PKCS7 envelope, matching the Renpho app's transport format ---
+
+function aesEncrypt(plaintext: string): string {
+  const cipher = createCipheriv('aes-128-ecb', Buffer.from(ENCRYPTION_KEY, 'utf8'), null)
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+  return encrypted.toString('base64')
+}
+
+function aesDecrypt(encryptedB64: string): string {
+  const decipher = createDecipheriv('aes-128-ecb', Buffer.from(ENCRYPTION_KEY, 'utf8'), null)
+  const decrypted = Buffer.concat([decipher.update(Buffer.from(encryptedB64, 'base64')), decipher.final()])
+  return decrypted.toString('utf8')
+}
+
+function encryptRequest(obj: unknown): { encryptData: string } {
+  return { encryptData: aesEncrypt(JSON.stringify(obj)) }
+}
+
+function decryptResponse<T = unknown>(encryptedData: string): T {
+  return JSON.parse(aesDecrypt(encryptedData))
+}
+
+export class RenphoAPIError extends Error {
+  code: unknown
+  constructor(context: string, code: unknown, msg: string) {
+    super(`${context} failed: code=${code}, msg=${msg}`)
+    this.code = code
+  }
+}
+
+function checkResponse(result: { code?: unknown; msg?: string }, context: string) {
+  const msg = (result.msg ?? '').toString()
+  if (msg.toLowerCase() === 'success' || SUCCESS_CODES.has(String(result.code))) return
+  throw new RenphoAPIError(context, result.code, msg)
+}
+
+export interface RenphoLoginResult {
+  token: string
+  userId: string
+}
+
+/** Authenticate with Renpho via email/password. Returns a session token + userId. */
+export async function loginToRenpho(email: string, password: string): Promise<RenphoLoginResult> {
+  const payload = {
+    questionnaire: {},
+    login: {
+      password,
+      areaCode: 'US',
+      appRevision: APP_VERSION,
+      cellphoneType: 'fitness-tracker',
+      systemType: SYSTEM_VERSION,
+      email,
+      platform: PLATFORM,
+    },
+    bindingList: { deviceTypes: BODY_WEIGHT_SCALES },
+  }
+
+  const res = await fetch(`${API_BASE_URL}/${ENDPOINTS.login}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(encryptRequest(payload)),
+  })
+  if (!res.ok) throw new Error(`Renpho login HTTP ${res.status}: ${await res.text()}`)
+
+  const result = await res.json()
+  checkResponse(result, 'Login')
+  const data = decryptResponse<{ login?: { token?: string; id?: string | number } }>(result.data)
+  const token = data.login?.token
+  const userId = data.login?.id
+  if (!token || userId == null) {
+    throw new RenphoAPIError('Login', null, 'No token/id in login response')
+  }
+  return { token, userId: String(userId) }
+}
+
+function authHeaders(token: string, userId: string): Record<string, string> {
+  return {
+    token,
+    userId,
+    appVersion: APP_VERSION,
+    platform: PLATFORM,
+  }
+}
+
+async function renphoPost<T = unknown>(
+  endpoint: string,
+  body: unknown,
+  token: string,
+  userId: string,
+  context: string,
+): Promise<T | null> {
+  const res = await fetch(`${API_BASE_URL}/${endpoint}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders(token, userId) },
+    body: JSON.stringify(encryptRequest(body)),
+  })
+  if (!res.ok) throw new Error(`Renpho ${context} HTTP ${res.status}: ${await res.text()}`)
+
+  const result = await res.json()
+  checkResponse(result, context)
+  if (!result.data) return null
+  return decryptResponse<T>(result.data)
+}
+
+interface RenphoScaleInfo {
+  tableName: string
+  count: number
+  userIds?: (string | number)[]
+}
+
+/** Get device info, including per-scale measurement table names and record counts. */
+export async function getRenphoDeviceInfo(token: string, userId: string): Promise<{ scale: RenphoScaleInfo[] }> {
+  const data = await renphoPost<{ scale?: RenphoScaleInfo[] }>(
+    ENDPOINTS.deviceInfo,
+    {},
+    token,
+    userId,
+    'GetDeviceInfo',
+  )
+  return { scale: data?.scale ?? [] }
+}
+
+/** Raw measurement record shape as returned by Renpho (fields vary by scale model). */
+export interface RenphoMeasurement {
+  id?: string | number
+  timeStamp?: number // epoch seconds
+  weight?: number // kg
+  bmi?: number
+  bodyfat?: number // %
+  water?: number // %
+  muscle?: number // %
+  bone?: number // %
+  bmr?: number // kcal/day
+  visfat?: number // level
+  subfat?: number // %
+  protein?: number // %
+  bodyage?: number // years
+  sinew?: number // kg, lean body mass
+  fatFreeWeight?: number // kg
+  heartRate?: number // bpm
+  [key: string]: unknown
+}
+
+function extractRecords(pageData: unknown): RenphoMeasurement[] | null {
+  if (Array.isArray(pageData)) return pageData.length > 0 ? pageData : null
+  if (pageData && typeof pageData === 'object') {
+    const obj = pageData as Record<string, unknown>
+    for (const key of ['list', 'data', 'records', 'measurements']) {
+      const value = obj[key]
+      if (Array.isArray(value)) return value.length > 0 ? (value as RenphoMeasurement[]) : null
+    }
+    if ('weight' in obj) return [obj as RenphoMeasurement]
+  }
+  return null
+}
+
+async function fetchMeasurementPages(
+  endpoint: string,
+  tableName: string,
+  userId: string,
+  token: string,
+  totalCount: number | null,
+  pageSize = 50,
+): Promise<RenphoMeasurement[]> {
+  const all: RenphoMeasurement[] = []
+  let page = 1
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (totalCount != null && all.length >= totalCount) break
+    const pageData = await renphoPost(
+      endpoint,
+      { pageNum: page, pageSize, userIds: [String(userId)], tableName },
+      token,
+      userId,
+      `Measurements page ${page}`,
+    )
+    const records = extractRecords(pageData)
+    if (!records) break
+    all.push(...records)
+    if (records.length < pageSize) break
+    page++
+  }
+  return all
+}
+
+/**
+ * High-level helper: log in (if needed), discover scale tables, and fetch
+ * every measurement across them. Mirrors RenphoClient.get_all_measurements().
+ */
+export async function fetchAllRenphoMeasurements(token: string, userId: string): Promise<RenphoMeasurement[]> {
+  const { scale } = await getRenphoDeviceInfo(token, userId)
+
+  const seen = new Set<string>()
+  const all: RenphoMeasurement[] = []
+
+  for (const s of scale) {
+    if (!s.tableName) continue
+    const uid = s.userIds && s.userIds.length > 0 && !s.userIds.map(String).includes(userId)
+      ? String(s.userIds[0])
+      : userId
+
+    // Body-composition endpoint first (impedance scales); the server-side
+    // count is unreliable for these, so always attempt it. Fall back to the
+    // legacy endpoint (weight-only scales) when it comes back empty.
+    let records = await fetchMeasurementPages(
+      ENDPOINTS.bodyCompositionMeasurements,
+      s.tableName,
+      uid,
+      token,
+      null,
+    )
+    if (records.length === 0 && s.count > 0) {
+      records = await fetchMeasurementPages(ENDPOINTS.measurements, s.tableName, uid, token, s.count)
+    }
+
+    for (const m of records) {
+      const key = `${s.tableName}:${m.id ?? ''}`
+      if (m.id != null && seen.has(key)) continue
+      if (m.id != null) seen.add(key)
+      all.push(m)
+    }
+  }
+
+  all.sort((a, b) => (b.timeStamp ?? 0) - (a.timeStamp ?? 0))
+  return all
+}
+
+const KG_TO_LBS = 2.20462
+
+/** Mapped shape used for storage — Renpho's kg fields converted to lbs to match the app's unit convention. */
+export interface MappedBodyMeasurement {
+  date: Date // local calendar date, midnight
+  weightLbs: number
+  bmi?: number
+  bodyFatPct?: number
+  waterPct?: number
+  musclePct?: number
+  boneMassPct?: number
+  bmr?: number
+  visceralFatLevel?: number
+  subcutaneousFatPct?: number
+  proteinPct?: number
+  bodyAgeYears?: number
+  leanBodyMassLbs?: number
+  fatFreeWeightLbs?: number
+  heartRateBpm?: number
+  renphoRecordId?: string
+}
+
+export function mapRenphoMeasurement(m: RenphoMeasurement): MappedBodyMeasurement | null {
+  if (m.weight == null) return null
+  const ts = m.timeStamp ? new Date(m.timeStamp * 1000) : new Date()
+  const date = new Date(ts.getFullYear(), ts.getMonth(), ts.getDate())
+
+  return {
+    date,
+    weightLbs: m.weight * KG_TO_LBS,
+    bmi: m.bmi,
+    bodyFatPct: m.bodyfat,
+    waterPct: m.water,
+    musclePct: m.muscle,
+    boneMassPct: m.bone,
+    bmr: m.bmr,
+    visceralFatLevel: m.visfat,
+    subcutaneousFatPct: m.subfat,
+    proteinPct: m.protein,
+    bodyAgeYears: m.bodyage,
+    leanBodyMassLbs: m.sinew != null ? m.sinew * KG_TO_LBS : undefined,
+    fatFreeWeightLbs: m.fatFreeWeight != null ? m.fatFreeWeight * KG_TO_LBS : undefined,
+    heartRateBpm: m.heartRate,
+    renphoRecordId: m.id != null ? String(m.id) : undefined,
+  }
+}
+
+/**
+ * Group mapped measurements by calendar date and keep the lowest-weight
+ * reading per day (per user preference — same-day readings favor the
+ * lowest number, e.g. a morning weigh-in vs. a post-meal one).
+ */
+export function pickDailyReadings(measurements: MappedBodyMeasurement[]): MappedBodyMeasurement[] {
+  const byDay = new Map<string, MappedBodyMeasurement>()
+  for (const m of measurements) {
+    const key = m.date.toISOString().slice(0, 10)
+    const existing = byDay.get(key)
+    if (!existing || m.weightLbs < existing.weightLbs) {
+      byDay.set(key, m)
+    }
+  }
+  return Array.from(byDay.values())
+}

--- a/src/types/health.ts
+++ b/src/types/health.ts
@@ -1,0 +1,25 @@
+// API payload shape for /api/body-measurements (dates as ISO strings over the wire)
+export interface BodyMeasurementApiRecord {
+  id: string
+  date: string
+  weightLbs: number
+  bmi?: number | null
+  bodyFatPct?: number | null
+  waterPct?: number | null
+  musclePct?: number | null
+  boneMassPct?: number | null
+  bmr?: number | null
+  visceralFatLevel?: number | null
+  subcutaneousFatPct?: number | null
+  proteinPct?: number | null
+  bodyAgeYears?: number | null
+  leanBodyMassLbs?: number | null
+  fatFreeWeightLbs?: number | null
+  heartRateBpm?: number | null
+  source: string
+}
+
+// Client-side shape, with `date` parsed to a Date.
+export interface BodyMeasurement extends Omit<BodyMeasurementApiRecord, 'date'> {
+  date: Date
+}


### PR DESCRIPTION
## Summary
Adds a **Health** tab for weight and body-composition trend tracking, sourced directly from Renpho instead of relaying through Apple Health.

## Why
Tonal's own profile only relays a single Apple Health-synced weight snapshot, and the Apple Health integration this app used to have was a pain to maintain. Renpho's (unofficial) API gives full history plus richer body-composition fields directly, cutting Apple Health out of the loop entirely.

## What's new
- `RenphoCredential` + `BodyMeasurement` Prisma models
- `src/lib/renpho.ts` — reverse-engineered Renpho API client (AES-128-ECB encrypted request/response envelope, email/password login), modeled on `danvaneijck/renpho-api`
- `src/lib/renpho-sync.ts` — sync orchestration; when a day has multiple scale readings, keeps the **lowest weight** per user preference
- `/api/renpho/auth`, `/api/renpho/sync`, `/api/body-measurements` routes, mirroring the existing Tonal/Peloton pattern (encrypted credentials, manual sync trigger)
- New `/health` page: current weight + 7/30-day change stat cards, a weight trend chart (recharts, with optional body fat %/muscle %/lean mass overlay), and a collapsible raw history table
- `Health` tab added to `NavTabs` (room to grow — sleep scores etc. later)
- `RENPHO_EMAIL` / `RENPHO_PASSWORD` documented in `.env.example`

## Verified
- `npx tsc --noEmit` — clean
- `npx eslint` on all new/changed files — clean
- `npx next build` — full production build succeeds, including the new `/health` route and API endpoints
- `RENPHO_EMAIL`/`RENPHO_PASSWORD` env vars already added to the deployment by the user

## Notes
- Unofficial API, same risk profile as the existing Tonal/Peloton integrations — no vendor support if Renpho changes it.
- New tables are created automatically on next deploy via the existing `prisma db push` build step; no manual migration needed.
