### PR TITLE
fix: nav tab wrap on mobile + Renpho device-info sync bug

### DIFF
--- a/src/components/HealthDashboard.tsx
+++ b/src/components/HealthDashboard.tsx
@@ -86,8 +86,12 @@ export function HealthDashboard() {
         if (data.synced > 0) parts.push(`${data.synced} new`)
         if (data.updated > 0) parts.push(`${data.updated} updated`)
         if (data.skipped > 0) parts.push(`${data.skipped} already synced`)
-        setSyncSuccess(`Renpho sync: ${parts.length > 0 ? parts.join(', ') : 'up to date'}`)
-        setTimeout(() => setSyncSuccess(null), 6000)
+        if (parts.length === 0 && data.scalesFound === 0) {
+          setSyncError('Renpho sync found 0 connected scales for this account — check RENPHO_EMAIL/RENPHO_PASSWORD, or that this account has a scale linked in the Renpho app.')
+        } else {
+          setSyncSuccess(`Renpho sync: ${parts.length > 0 ? parts.join(', ') : 'up to date'}`)
+          setTimeout(() => setSyncSuccess(null), 6000)
+        }
       } else {
         setSyncError(`Renpho sync failed: ${data.error || res.status}`)
       }

--- a/src/components/NavTabs.tsx
+++ b/src/components/NavTabs.tsx
@@ -14,20 +14,23 @@ export function NavTabs() {
   const pathname = usePathname()
 
   return (
-    <nav className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1 w-fit" aria-label="Sections">
+    <nav
+      className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1 w-fit max-w-full overflow-x-auto"
+      aria-label="Sections"
+    >
       {TABS.map(({ href, label, icon: Icon }) => {
         const active = pathname === href
         return (
           <Link
             key={href}
             href={href}
-            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors shrink-0 whitespace-nowrap ${
               active
                 ? 'bg-white dark:bg-gray-700 shadow-sm text-primary-600 dark:text-primary-400'
                 : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
             }`}
           >
-            <Icon className="w-4 h-4" />
+            <Icon className="w-4 h-4 shrink-0" />
             <span>{label}</span>
           </Link>
         )

--- a/src/lib/renpho-sync.ts
+++ b/src/lib/renpho-sync.ts
@@ -19,6 +19,7 @@ export interface RenphoSyncResult {
   updated: number
   skipped: number
   total: number
+  scalesFound: number
 }
 
 export class RenphoSyncError extends Error {
@@ -92,7 +93,7 @@ export async function runRenphoSync(): Promise<RenphoSyncResult> {
     }
   }
 
-  const rawMeasurements = await withReauthRetry(() =>
+  const { measurements: rawMeasurements, scalesFound } = await withReauthRetry(() =>
     fetchAllRenphoMeasurements(decryptSecret(cred.token), cred.userId),
   )
   const total = rawMeasurements.length
@@ -135,5 +136,5 @@ export async function runRenphoSync(): Promise<RenphoSyncResult> {
     }
   }
 
-  return { synced, updated, skipped, total }
+  return { synced, updated, skipped, total, scalesFound }
 }

--- a/src/lib/renpho.ts
+++ b/src/lib/renpho.ts
@@ -47,6 +47,11 @@ function encryptRequest(obj: unknown): { encryptData: string } {
   return { encryptData: aesEncrypt(JSON.stringify(obj)) }
 }
 
+/** Encrypt an empty byte string (not `{}`) — some endpoints (device info) expect this on the first attempt. */
+function encryptEmptyBytes(): { encryptData: string } {
+  return { encryptData: aesEncrypt('') }
+}
+
 function decryptResponse<T = unknown>(encryptedData: string): T {
   return JSON.parse(aesDecrypt(encryptedData))
 }
@@ -113,6 +118,26 @@ function authHeaders(token: string, userId: string): Record<string, string> {
   }
 }
 
+async function renphoPostRaw<T = unknown>(
+  endpoint: string,
+  encryptedBody: { encryptData: string },
+  token: string,
+  userId: string,
+  context: string,
+): Promise<{ ok: true; data: T | null } | { ok: false; status: number; text: string }> {
+  const res = await fetch(`${API_BASE_URL}/${endpoint}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders(token, userId) },
+    body: JSON.stringify(encryptedBody),
+  })
+  if (!res.ok) return { ok: false, status: res.status, text: await res.text() }
+
+  const result = await res.json()
+  checkResponse(result, context)
+  if (!result.data) return { ok: true, data: null }
+  return { ok: true, data: decryptResponse<T>(result.data) }
+}
+
 async function renphoPost<T = unknown>(
   endpoint: string,
   body: unknown,
@@ -120,17 +145,9 @@ async function renphoPost<T = unknown>(
   userId: string,
   context: string,
 ): Promise<T | null> {
-  const res = await fetch(`${API_BASE_URL}/${endpoint}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...authHeaders(token, userId) },
-    body: JSON.stringify(encryptRequest(body)),
-  })
-  if (!res.ok) throw new Error(`Renpho ${context} HTTP ${res.status}: ${await res.text()}`)
-
-  const result = await res.json()
-  checkResponse(result, context)
-  if (!result.data) return null
-  return decryptResponse<T>(result.data)
+  const result = await renphoPostRaw<T>(endpoint, encryptRequest(body), token, userId, context)
+  if (!result.ok) throw new Error(`Renpho ${context} HTTP ${result.status}: ${result.text}`)
+  return result.data
 }
 
 interface RenphoScaleInfo {
@@ -139,16 +156,41 @@ interface RenphoScaleInfo {
   userIds?: (string | number)[]
 }
 
-/** Get device info, including per-scale measurement table names and record counts. */
+/**
+ * Get device info, including per-scale measurement table names and record
+ * counts. Mirrors the reference client: the real Renpho app's first attempt
+ * encrypts an *empty byte string* (not `{}`) for this specific endpoint;
+ * only on an HTTP-level failure does it fall back to encrypted `{}`. Sending
+ * `{}` as the primary (and only) attempt — the original bug here — got a
+ * 200 back but with no usable scale data, which silently produced zero
+ * measurements on every sync with no error surfaced.
+ */
 export async function getRenphoDeviceInfo(token: string, userId: string): Promise<{ scale: RenphoScaleInfo[] }> {
-  const data = await renphoPost<{ scale?: RenphoScaleInfo[] }>(
+  type DeviceInfoData = { scale?: RenphoScaleInfo[] }
+
+  let result = await renphoPostRaw<DeviceInfoData>(
     ENDPOINTS.deviceInfo,
-    {},
+    encryptEmptyBytes(),
     token,
     userId,
-    'GetDeviceInfo',
+    'GetDeviceInfo (empty-bytes)',
   )
-  return { scale: data?.scale ?? [] }
+  if (!result.ok) {
+    result = await renphoPostRaw<DeviceInfoData>(
+      ENDPOINTS.deviceInfo,
+      encryptRequest({}),
+      token,
+      userId,
+      'GetDeviceInfo (empty-object fallback)',
+    )
+  }
+  if (!result.ok) {
+    throw new Error(`Renpho GetDeviceInfo HTTP ${result.status}: ${result.text}`)
+  }
+
+  const scale = result.data?.scale ?? []
+  console.log(`[renpho] device info: ${scale.length} scale(s) found`)
+  return { scale }
 }
 
 /** Raw measurement record shape as returned by Renpho (fields vary by scale model). */
@@ -218,8 +260,11 @@ async function fetchMeasurementPages(
  * High-level helper: log in (if needed), discover scale tables, and fetch
  * every measurement across them. Mirrors RenphoClient.get_all_measurements().
  */
-export async function fetchAllRenphoMeasurements(token: string, userId: string): Promise<RenphoMeasurement[]> {
+export async function fetchAllRenphoMeasurements(token: string, userId: string): Promise<{ measurements: RenphoMeasurement[]; scalesFound: number }> {
   const { scale } = await getRenphoDeviceInfo(token, userId)
+  if (scale.length === 0) {
+    console.warn('[renpho] device info returned zero scales - nothing to sync. Check credentials/API changes.')
+  }
 
   const seen = new Set<string>()
   const all: RenphoMeasurement[] = []
@@ -243,6 +288,7 @@ export async function fetchAllRenphoMeasurements(token: string, userId: string):
     if (records.length === 0 && s.count > 0) {
       records = await fetchMeasurementPages(ENDPOINTS.measurements, s.tableName, uid, token, s.count)
     }
+    console.log(`[renpho] table=${s.tableName} reportedCount=${s.count} fetched=${records.length}`)
 
     for (const m of records) {
       const key = `${s.tableName}:${m.id ?? ''}`
@@ -253,7 +299,7 @@ export async function fetchAllRenphoMeasurements(token: string, userId: string):
   }
 
   all.sort((a, b) => (b.timeStamp ?? 0) - (a.timeStamp ?? 0))
-  return all
+  return { measurements: all, scalesFound: scale.length }
 }
 
 const KG_TO_LBS = 2.20462


### PR DESCRIPTION
## Fixes two issues reported after the Renpho Health tracking PR (#26)

### 1. Nav tabs wrapping on mobile
`NavTabs` had no shrink protection, so squeezing it next to the theme toggle on a narrow viewport caused tab labels to wrap mid-word (e.g. "Free Weights" breaking onto two lines) instead of the row handling the overflow gracefully.

**Fix:** `whitespace-nowrap` + `shrink-0` on each tab, `overflow-x-auto` on the nav container so on very narrow screens it scrolls horizontally instead of squeezing/wrapping text.

### 2. Sync reporting "up to date" with zero data
Root cause: `device/count` (device info) was always called with an encrypted `{}` body. The real Renpho client's first attempt encrypts an **empty byte string** instead, only falling back to `{}` on an HTTP-level failure. Sending `{}` as the only attempt got an HTTP 200 back but with no usable scale list \u2014 so every sync silently found 0 scales, fetched 0 measurements, and reported success with nothing to show, no error surfaced.

**Fix:** `getRenphoDeviceInfo` now matches the real client's request order (empty-bytes first, `{}` fallback only on HTTP failure). Also added a `scalesFound` diagnostic to the sync result plus server-side logging, so if this ever regresses again the UI shows a clear error instead of a silent no-op.

**How I verified the fix direction:** before touching the sync path, I round-tripped the AES-128-ECB envelope locally and sent a real (deliberately wrong-credential) login request to `cloud.renpho.com` from this workspace. The server decrypted it fine and returned a structured `{"code":106,"msg":"user does not exist"}` error \u2014 confirming the crypto layer and login endpoint shape were correct, which narrowed the bug down to the device-info request.

## Verified
- `npx tsc --noEmit` \u2014 clean
- `npx eslint` on changed files \u2014 clean
- `npx next build` \u2014 full production build succeeds
- Could not fully verify against your real Renpho account from this sandbox (no live credentials here) \u2014 please re-run Sync and confirm your Aug 2 weigh-in shows up.
