### PR TITLE
feat: add live Renpho diagnostics + surface real sync errors

### DIFF
--- a/src/app/api/renpho/auth/route.ts
+++ b/src/app/api/renpho/auth/route.ts
@@ -12,9 +12,11 @@ export async function POST(request: Request) {
     return NextResponse.json({ connected: true, userId: cred.userId })
   } catch (error) {
     if (error instanceof RenphoSyncError) {
+      console.error('Renpho auth error (RenphoSyncError):', error.message)
       return NextResponse.json({ error: error.message }, { status: error.status })
     }
-    console.error('💥 Renpho auth error:', error instanceof Error ? error.message : error)
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    const message = error instanceof Error ? error.message : String(error)
+    console.error('Renpho auth error:', message, error instanceof Error ? error.stack : undefined)
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }

--- a/src/app/api/renpho/debug/route.ts
+++ b/src/app/api/renpho/debug/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth'
+import { loginToRenpho, debugDeviceInfoAttempts, fetchAllRenphoMeasurements } from '@/lib/renpho'
+
+/**
+ * Live diagnostic trace for the Renpho integration. Does NOT touch stored
+ * credentials or the database — logs in fresh with the env-configured
+ * account and reports exactly what each step returned, so a broken sync
+ * can be diagnosed from the response body alone instead of digging through
+ * Vercel function logs.
+ *
+ * Never returns the password or the raw session token.
+ */
+export async function GET(request: Request) {
+  const authResult = await requireAuth(request)
+  if (authResult instanceof NextResponse) return authResult
+
+  const email = process.env.RENPHO_EMAIL?.trim()
+  const password = process.env.RENPHO_PASSWORD?.trim()
+
+  const report: Record<string, unknown> = {
+    envVarsPresent: { RENPHO_EMAIL: !!email, RENPHO_PASSWORD: !!password },
+  }
+
+  if (!email || !password) {
+    report.result = 'FAILED: RENPHO_EMAIL and/or RENPHO_PASSWORD are not set in this environment.'
+    return NextResponse.json(report, { status: 200 })
+  }
+
+  let token: string
+  let userId: string
+  try {
+    const login = await loginToRenpho(email, password)
+    token = login.token
+    userId = login.userId
+    report.login = { ok: true, userId, tokenLength: token.length }
+  } catch (error) {
+    report.login = { ok: false, error: error instanceof Error ? error.message : String(error) }
+    report.result = 'FAILED at login. See report.login.error above.'
+    return NextResponse.json(report, { status: 200 })
+  }
+
+  try {
+    report.deviceInfoAttempts = await debugDeviceInfoAttempts(token, userId)
+  } catch (error) {
+    report.deviceInfoAttempts = { error: error instanceof Error ? error.message : String(error) }
+  }
+
+  try {
+    const { measurements, scalesFound } = await fetchAllRenphoMeasurements(token, userId)
+    report.fetchAllMeasurements = {
+      ok: true,
+      scalesFound,
+      totalMeasurements: measurements.length,
+      newestSample: measurements[0] ?? null,
+      oldestSample: measurements[measurements.length - 1] ?? null,
+    }
+    report.result = measurements.length > 0
+      ? `OK: fetched ${measurements.length} raw measurements across ${scalesFound} scale(s).`
+      : `FAILED: login succeeded but 0 measurements were fetched (scalesFound=${scalesFound}). See deviceInfoAttempts above for why.`
+  } catch (error) {
+    report.fetchAllMeasurements = { ok: false, error: error instanceof Error ? error.message : String(error) }
+    report.result = 'FAILED while fetching measurements. See report.fetchAllMeasurements.error above.'
+  }
+
+  return NextResponse.json(report, { status: 200 })
+}

--- a/src/app/api/renpho/sync/route.ts
+++ b/src/app/api/renpho/sync/route.ts
@@ -36,11 +36,15 @@ export async function POST(req: Request) {
     return NextResponse.json(result)
   } catch (error) {
     if (error instanceof RenphoSyncError) {
+      console.error('Renpho sync error (RenphoSyncError):', error.message)
       return NextResponse.json({ error: error.message }, { status: error.status })
     }
-    const message = error instanceof Error ? error.message : 'Unknown error'
-    console.error('Renpho sync error:', message)
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    const message = error instanceof Error ? error.message : String(error)
+    const stack = error instanceof Error ? error.stack : undefined
+    console.error('Renpho sync error:', message, stack)
+    // Personal single-user app — safe to surface the real error to the
+    // one authenticated user instead of masking it as a generic 500.
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }
 

--- a/src/components/HealthDashboard.tsx
+++ b/src/components/HealthDashboard.tsx
@@ -10,6 +10,16 @@ function parseMeasurement(raw: BodyMeasurementApiRecord): BodyMeasurement {
   return { ...raw, date: new Date(raw.date) }
 }
 
+/** Reads a fetch Response defensively: never throws on non-JSON bodies (Vercel timeout/error pages, etc). */
+async function safeJson(res: Response): Promise<{ status: number; ok: boolean; json: Record<string, unknown> | null; rawText: string }> {
+  const rawText = await res.text()
+  try {
+    return { status: res.status, ok: res.ok, json: JSON.parse(rawText), rawText }
+  } catch {
+    return { status: res.status, ok: res.ok, json: null, rawText }
+  }
+}
+
 interface ChangeStatProps {
   label: string
   current: number | null
@@ -46,6 +56,9 @@ export function HealthDashboard() {
   const [syncError, setSyncError] = useState<string | null>(null)
   const [syncSuccess, setSyncSuccess] = useState<string | null>(null)
   const [showTable, setShowTable] = useState(false)
+  const [diagLoading, setDiagLoading] = useState(false)
+  const [diagResult, setDiagResult] = useState<string | null>(null)
+  const [showDiag, setShowDiag] = useState(false)
 
   const loadData = useCallback(async () => {
     try {
@@ -68,37 +81,59 @@ export function HealthDashboard() {
     setSyncing(true)
     setSyncError(null)
     try {
-      const statusRes = await fetch('/api/renpho/sync')
-      const statusData = await statusRes.json()
-      if (!statusData.connected) {
-        const authRes = await fetch('/api/renpho/auth', { method: 'POST' })
+      const statusRes = await safeJson(await fetch('/api/renpho/sync'))
+      const connected = statusRes.json?.connected === true
+
+      if (!connected) {
+        const authRes = await safeJson(await fetch('/api/renpho/auth', { method: 'POST' }))
         if (!authRes.ok) {
-          const err = await authRes.json().catch(() => ({ error: 'Auth failed' }))
-          setSyncError(`Renpho auth failed: ${err.error || authRes.status}`)
+          const detail = authRes.json?.error ?? authRes.rawText.slice(0, 300) ?? 'no response body'
+          setSyncError(`Renpho auth failed (HTTP ${authRes.status}): ${detail}`)
           return
         }
       }
-      const res = await fetch('/api/renpho/sync', { method: 'POST' })
-      const data = await res.json()
-      if (res.ok) {
-        if (data.synced > 0 || data.updated > 0) await loadData()
-        const parts: string[] = []
-        if (data.synced > 0) parts.push(`${data.synced} new`)
-        if (data.updated > 0) parts.push(`${data.updated} updated`)
-        if (data.skipped > 0) parts.push(`${data.skipped} already synced`)
-        if (parts.length === 0 && data.scalesFound === 0) {
-          setSyncError('Renpho sync found 0 connected scales for this account — check RENPHO_EMAIL/RENPHO_PASSWORD, or that this account has a scale linked in the Renpho app.')
-        } else {
-          setSyncSuccess(`Renpho sync: ${parts.length > 0 ? parts.join(', ') : 'up to date'}`)
-          setTimeout(() => setSyncSuccess(null), 6000)
-        }
+
+      const syncRes = await safeJson(await fetch('/api/renpho/sync', { method: 'POST' }))
+      if (!syncRes.ok) {
+        const detail = syncRes.json?.error ?? syncRes.rawText.slice(0, 300) ?? 'no response body'
+        setSyncError(`Renpho sync failed (HTTP ${syncRes.status}): ${detail}`)
+        return
+      }
+      if (!syncRes.json) {
+        setSyncError(`Renpho sync returned a non-JSON response (HTTP ${syncRes.status}): ${syncRes.rawText.slice(0, 300)}`)
+        return
+      }
+
+      const data = syncRes.json as { synced?: number; updated?: number; skipped?: number; scalesFound?: number }
+      if ((data.synced ?? 0) > 0 || (data.updated ?? 0) > 0) await loadData()
+      const parts: string[] = []
+      if ((data.synced ?? 0) > 0) parts.push(`${data.synced} new`)
+      if ((data.updated ?? 0) > 0) parts.push(`${data.updated} updated`)
+      if ((data.skipped ?? 0) > 0) parts.push(`${data.skipped} already synced`)
+      if (parts.length === 0 && data.scalesFound === 0) {
+        setSyncError('Renpho sync found 0 connected scales for this account. Click "Run Diagnostics" below for a detailed trace of why.')
       } else {
-        setSyncError(`Renpho sync failed: ${data.error || res.status}`)
+        setSyncSuccess(`Renpho sync: ${parts.length > 0 ? parts.join(', ') : 'up to date'}`)
+        setTimeout(() => setSyncSuccess(null), 6000)
       }
     } catch (error) {
-      setSyncError(`Renpho sync failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
+      setSyncError(`Renpho sync threw an unexpected error: ${error instanceof Error ? error.message : String(error)}`)
     } finally {
       setSyncing(false)
+    }
+  }
+
+  const handleDiagnostics = async () => {
+    setDiagLoading(true)
+    setDiagResult(null)
+    setShowDiag(true)
+    try {
+      const res = await safeJson(await fetch('/api/renpho/debug'))
+      setDiagResult(res.json ? JSON.stringify(res.json, null, 2) : `HTTP ${res.status} (non-JSON):\n${res.rawText}`)
+    } catch (error) {
+      setDiagResult(`Diagnostics request itself failed: ${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      setDiagLoading(false)
     }
   }
 
@@ -126,18 +161,49 @@ export function HealthDashboard() {
           <p className="text-sm text-gray-600 dark:text-gray-400">Weight and body composition trends, synced from Renpho</p>
         </div>
         <div className="flex flex-col items-end gap-1">
-          <button
-            onClick={handleSync}
-            disabled={syncing}
-            className="bg-primary-500 hover:bg-primary-600 disabled:opacity-50 text-white px-3 py-1.5 rounded-lg font-medium transition-colors flex items-center gap-1.5 shadow-sm text-sm"
-          >
-            <RefreshCw className={`w-4 h-4 ${syncing ? 'animate-spin' : ''}`} />
-            <span>{syncing ? 'Syncing…' : 'Sync Renpho'}</span>
-          </button>
-          {syncError && <p className="text-xs text-red-600 dark:text-red-400 max-w-xs text-right">{syncError}</p>}
-          {syncSuccess && <p className="text-xs text-green-600 dark:text-green-400 max-w-xs text-right">{syncSuccess}</p>}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleSync}
+              disabled={syncing}
+              className="bg-primary-500 hover:bg-primary-600 disabled:opacity-50 text-white px-3 py-1.5 rounded-lg font-medium transition-colors flex items-center gap-1.5 shadow-sm text-sm"
+            >
+              <RefreshCw className={`w-4 h-4 ${syncing ? 'animate-spin' : ''}`} />
+              <span>{syncing ? 'Syncing…' : 'Sync Renpho'}</span>
+            </button>
+            <button
+              onClick={handleDiagnostics}
+              disabled={diagLoading}
+              className="bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 text-gray-700 dark:text-gray-300 px-3 py-1.5 rounded-lg font-medium transition-colors text-sm"
+            >
+              {diagLoading ? 'Running…' : 'Run Diagnostics'}
+            </button>
+          </div>
+          {syncError && <p className="text-xs text-red-600 dark:text-red-400 max-w-sm text-right">{syncError}</p>}
+          {syncSuccess && <p className="text-xs text-green-600 dark:text-green-400 max-w-sm text-right">{syncSuccess}</p>}
         </div>
       </div>
+
+      {showDiag && (
+        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+              Renpho Diagnostics {diagLoading && '(running…)'}
+            </span>
+            <button
+              onClick={() => setShowDiag(false)}
+              className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
+            >
+              Close
+            </button>
+          </div>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+            Live trace of login → device info → measurement fetch, using the account configured in RENPHO_EMAIL/RENPHO_PASSWORD. No password or session token is included below — safe to copy/paste for troubleshooting.
+          </p>
+          <pre className="text-xs bg-gray-50 dark:bg-gray-800 rounded-lg p-3 overflow-x-auto whitespace-pre-wrap break-words max-h-96 overflow-y-auto">
+            {diagResult ?? 'Running…'}
+          </pre>
+        </div>
+      )}
 
       {/* Stat cards */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">

--- a/src/lib/renpho.ts
+++ b/src/lib/renpho.ts
@@ -157,6 +157,62 @@ interface RenphoScaleInfo {
 }
 
 /**
+ * Diagnostic-only helper: run both device-info request variants
+ * unconditionally (regardless of whether the first succeeds) and report
+ * raw details for each, without throwing. Used by /api/renpho/debug so a
+ * broken sync can be diagnosed without digging through server logs.
+ */
+export async function debugDeviceInfoAttempts(token: string, userId: string) {
+  type DeviceInfoData = { scale?: RenphoScaleInfo[] }
+
+  async function describe(label: string, body: { encryptData: string }) {
+    try {
+      const res = await fetch(`${API_BASE_URL}/${ENDPOINTS.deviceInfo}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders(token, userId) },
+        body: JSON.stringify(body),
+      })
+      const rawText = await res.text()
+      if (!res.ok) {
+        return { attempt: label, httpStatus: res.status, httpOk: false, rawText: rawText.slice(0, 500) }
+      }
+      let parsed: { code?: unknown; msg?: string; data?: string }
+      try {
+        parsed = JSON.parse(rawText)
+      } catch {
+        return { attempt: label, httpStatus: res.status, httpOk: true, rawText: rawText.slice(0, 500), parseError: 'response was not JSON' }
+      }
+      let decrypted: DeviceInfoData | null = null
+      let decryptError: string | null = null
+      if (parsed.data) {
+        try {
+          decrypted = decryptResponse<DeviceInfoData>(parsed.data)
+        } catch (e) {
+          decryptError = e instanceof Error ? e.message : String(e)
+        }
+      }
+      return {
+        attempt: label,
+        httpStatus: res.status,
+        httpOk: true,
+        code: parsed.code,
+        msg: parsed.msg,
+        hasDataField: parsed.data != null,
+        decryptError,
+        scaleCount: decrypted?.scale?.length ?? null,
+        scaleTableNames: decrypted?.scale?.map(s => s.tableName) ?? null,
+      }
+    } catch (e) {
+      return { attempt: label, error: e instanceof Error ? e.message : String(e) }
+    }
+  }
+
+  const emptyBytesResult = await describe('empty-bytes', encryptEmptyBytes())
+  const emptyObjectResult = await describe('empty-object', encryptRequest({}))
+  return { emptyBytesResult, emptyObjectResult }
+}
+
+/**
  * Get device info, including per-scale measurement table names and record
  * counts. Mirrors the reference client: the real Renpho app's first attempt
  * encrypts an *empty byte string* (not `{}`) for this specific endpoint;


### PR DESCRIPTION
## Why
Sync is still not working after #27, and the error surfacing was too thin to tell why ("up to date", no data, no useful error). This PR doesn't change the sync logic itself further \u2014 it adds the tooling needed to actually see what's failing, since I don't have access to your Renpho credentials or Vercel logs from here.

## What's new
- **`GET /api/renpho/debug`** \u2014 a live diagnostic trace: logs in with the configured account, runs *both* device-info request variants (the empty-bytes and empty-object attempts) regardless of which succeeds, and fetches all measurements \u2014 reporting HTTP status, API code/msg, scale count, table names, and decrypt errors at each step. Never touches stored credentials, never returns the password or session token.
- **"Run Diagnostics" button** on the Health page, next to Sync Renpho \u2014 calls the above and shows the raw JSON trace inline so you can read (or copy/paste back to me) exactly where it's failing.
- **Hardened `handleSync`**: every API response is now read as text first, so a non-JSON response (e.g. a Vercel function timeout page) shows up verbatim instead of throwing an opaque "Unexpected token" error or failing with no visible message.
- **`/api/renpho/auth` and `/api/renpho/sync` no longer mask errors** behind "Internal server error" \u2014 since this is a personal single-user app, the real error message (and stack, server-side) is now returned and logged.

## Next step
After this deploys, please click **Run Diagnostics** on the Health page and share the JSON output \u2014 that'll tell us definitively whether it's failing at login, at device-info, or at measurement fetch, and why.

## Verified
- `npx tsc --noEmit` \u2014 clean
- `npx eslint` on changed/new files \u2014 clean
- `npx next build` \u2014 full production build succeeds, including the new `/api/renpho/debug` route
