### PR TITLE
feat: per-table measurement probe in diagnostics + result-first ordering

### DIFF
--- a/src/app/api/renpho/debug/route.ts
+++ b/src/app/api/renpho/debug/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from 'next/server'
 import { requireAuth } from '@/lib/auth'
-import { loginToRenpho, debugDeviceInfoAttempts, fetchAllRenphoMeasurements } from '@/lib/renpho'
+import {
+  loginToRenpho,
+  debugDeviceInfoAttempts,
+  debugMeasurementFetch,
+  getRenphoDeviceInfo,
+  fetchAllRenphoMeasurements,
+} from '@/lib/renpho'
 
 /**
  * Live diagnostic trace for the Renpho integration. Does NOT touch stored
@@ -9,7 +15,9 @@ import { loginToRenpho, debugDeviceInfoAttempts, fetchAllRenphoMeasurements } fr
  * can be diagnosed from the response body alone instead of digging through
  * Vercel function logs.
  *
- * Never returns the password or the raw session token.
+ * Never returns the password or the raw session token. `result` is placed
+ * first in the object (reassigned in place as the trace progresses) so it's
+ * the first thing visible without scrolling through the rest of the trace.
  */
 export async function GET(request: Request) {
   const authResult = await requireAuth(request)
@@ -19,6 +27,7 @@ export async function GET(request: Request) {
   const password = process.env.RENPHO_PASSWORD?.trim()
 
   const report: Record<string, unknown> = {
+    result: 'pending',
     envVarsPresent: { RENPHO_EMAIL: !!email, RENPHO_PASSWORD: !!password },
   }
 
@@ -47,6 +56,20 @@ export async function GET(request: Request) {
   }
 
   try {
+    const { scale } = await getRenphoDeviceInfo(token, userId)
+    report.perTableProbe = await Promise.all(
+      scale.map(s => {
+        const uid = s.userIds && s.userIds.length > 0 && !s.userIds.map(String).includes(userId)
+          ? String(s.userIds[0])
+          : userId
+        return debugMeasurementFetch(token, userId, s.tableName, uid, s.count)
+      }),
+    )
+  } catch (error) {
+    report.perTableProbe = { error: error instanceof Error ? error.message : String(error) }
+  }
+
+  try {
     const { measurements, scalesFound } = await fetchAllRenphoMeasurements(token, userId)
     report.fetchAllMeasurements = {
       ok: true,
@@ -57,7 +80,7 @@ export async function GET(request: Request) {
     }
     report.result = measurements.length > 0
       ? `OK: fetched ${measurements.length} raw measurements across ${scalesFound} scale(s).`
-      : `FAILED: login succeeded but 0 measurements were fetched (scalesFound=${scalesFound}). See deviceInfoAttempts above for why.`
+      : `FAILED: login and device-info succeeded (scalesFound=${scalesFound}) but 0 measurements were fetched. See perTableProbe above for the raw per-endpoint response.`
   } catch (error) {
     report.fetchAllMeasurements = { ok: false, error: error instanceof Error ? error.message : String(error) }
     report.result = 'FAILED while fetching measurements. See report.fetchAllMeasurements.error above.'

--- a/src/components/HealthDashboard.tsx
+++ b/src/components/HealthDashboard.tsx
@@ -58,6 +58,8 @@ export function HealthDashboard() {
   const [showTable, setShowTable] = useState(false)
   const [diagLoading, setDiagLoading] = useState(false)
   const [diagResult, setDiagResult] = useState<string | null>(null)
+  const [diagSummary, setDiagSummary] = useState<string | null>(null)
+  const [diagCopied, setDiagCopied] = useState(false)
   const [showDiag, setShowDiag] = useState(false)
 
   const loadData = useCallback(async () => {
@@ -126,14 +128,32 @@ export function HealthDashboard() {
   const handleDiagnostics = async () => {
     setDiagLoading(true)
     setDiagResult(null)
+    setDiagSummary(null)
+    setDiagCopied(false)
     setShowDiag(true)
     try {
       const res = await safeJson(await fetch('/api/renpho/debug'))
-      setDiagResult(res.json ? JSON.stringify(res.json, null, 2) : `HTTP ${res.status} (non-JSON):\n${res.rawText}`)
+      if (res.json) {
+        setDiagSummary(typeof res.json.result === 'string' ? res.json.result : null)
+        setDiagResult(JSON.stringify(res.json, null, 2))
+      } else {
+        setDiagResult(`HTTP ${res.status} (non-JSON):\n${res.rawText}`)
+      }
     } catch (error) {
       setDiagResult(`Diagnostics request itself failed: ${error instanceof Error ? error.message : String(error)}`)
     } finally {
       setDiagLoading(false)
+    }
+  }
+
+  const handleCopyDiag = async () => {
+    if (!diagResult) return
+    try {
+      await navigator.clipboard.writeText(diagResult)
+      setDiagCopied(true)
+      setTimeout(() => setDiagCopied(false), 2000)
+    } catch {
+      // Clipboard API unavailable (e.g. non-HTTPS context) — the text is still selectable/visible.
     }
   }
 
@@ -185,17 +205,32 @@ export function HealthDashboard() {
 
       {showDiag && (
         <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4">
-          <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center justify-between mb-2 gap-2">
             <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
               Renpho Diagnostics {diagLoading && '(running…)'}
             </span>
-            <button
-              onClick={() => setShowDiag(false)}
-              className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
-            >
-              Close
-            </button>
+            <div className="flex items-center gap-3 shrink-0">
+              {diagResult && (
+                <button
+                  onClick={handleCopyDiag}
+                  className="text-xs text-primary-600 dark:text-primary-400 hover:underline"
+                >
+                  {diagCopied ? 'Copied!' : 'Copy JSON'}
+                </button>
+              )}
+              <button
+                onClick={() => setShowDiag(false)}
+                className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
+              >
+                Close
+              </button>
+            </div>
           </div>
+          {diagSummary && (
+            <p className={`text-sm font-medium mb-2 ${diagSummary.startsWith('OK') ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+              {diagSummary}
+            </p>
+          )}
           <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
             Live trace of login → device info → measurement fetch, using the account configured in RENPHO_EMAIL/RENPHO_PASSWORD. No password or session token is included below — safe to copy/paste for troubleshooting.
           </p>

--- a/src/lib/renpho.ts
+++ b/src/lib/renpho.ts
@@ -150,7 +150,7 @@ async function renphoPost<T = unknown>(
   return result.data
 }
 
-interface RenphoScaleInfo {
+export interface RenphoScaleInfo {
   tableName: string
   count: number
   userIds?: (string | number)[]
@@ -210,6 +210,68 @@ export async function debugDeviceInfoAttempts(token: string, userId: string) {
   const emptyBytesResult = await describe('empty-bytes', encryptEmptyBytes())
   const emptyObjectResult = await describe('empty-object', encryptRequest({}))
   return { emptyBytesResult, emptyObjectResult }
+}
+
+/**
+ * Diagnostic-only helper: probe a single scale table with a small page
+ * request against BOTH the body-composition and legacy measurement
+ * endpoints, unconditionally, and report raw details for each — without
+ * throwing. Used by /api/renpho/debug to show exactly why a table did or
+ * didn't yield records during a real sync.
+ */
+export async function debugMeasurementFetch(
+  token: string,
+  userId: string,
+  tableName: string,
+  scaleUserId: string,
+  reportedCount: number,
+) {
+  async function describe(label: string, endpoint: string) {
+    try {
+      const res = await fetch(`${API_BASE_URL}/${endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders(token, scaleUserId) },
+        body: JSON.stringify(encryptRequest({ pageNum: 1, pageSize: 5, userIds: [String(scaleUserId)], tableName })),
+      })
+      const rawText = await res.text()
+      if (!res.ok) {
+        return { attempt: label, httpStatus: res.status, httpOk: false, rawText: rawText.slice(0, 500) }
+      }
+      let parsed: { code?: unknown; msg?: string; data?: string }
+      try {
+        parsed = JSON.parse(rawText)
+      } catch {
+        return { attempt: label, httpStatus: res.status, httpOk: true, rawText: rawText.slice(0, 500), parseError: 'response was not JSON' }
+      }
+      let decryptError: string | null = null
+      let recordsPreview: unknown = null
+      if (parsed.data) {
+        try {
+          const decrypted = decryptResponse(parsed.data)
+          const records = extractRecords(decrypted)
+          recordsPreview = records ? records.slice(0, 2) : decrypted
+        } catch (e) {
+          decryptError = e instanceof Error ? e.message : String(e)
+        }
+      }
+      return {
+        attempt: label,
+        httpStatus: res.status,
+        httpOk: true,
+        code: parsed.code,
+        msg: parsed.msg,
+        hasDataField: parsed.data != null,
+        decryptError,
+        recordsPreview,
+      }
+    } catch (e) {
+      return { attempt: label, error: e instanceof Error ? e.message : String(e) }
+    }
+  }
+
+  const bodyCompositionResult = await describe('body-composition', ENDPOINTS.bodyCompositionMeasurements)
+  const legacyResult = await describe('legacy', ENDPOINTS.measurements)
+  return { tableName, scaleUserId, reportedCount, bodyCompositionResult, legacyResult }
 }
 
 /**


### PR DESCRIPTION
## Why
The last diagnostic run (thanks for sharing it!) showed login and device-info both succeeding cleanly: scaleCount 1, table `measurements_info_9`. But `fetchAllMeasurements` still returned 0 records. That confirms the #27 device-info fix was correct but wasn't the whole story \u2014 the remaining fault is inside the per-table measurement fetch itself (body-composition and/or legacy endpoint).

## What's new
- `debugMeasurementFetch()` \u2014 probes a table with a small page request against **both** the body-composition and legacy endpoints unconditionally, reporting raw HTTP status, API code/msg, decrypt errors, and a small preview of any records returned.
- `/api/renpho/debug` now runs this probe against every table device-info reports, included as `perTableProbe` in the trace \u2014 this is the missing piece that will show exactly why `measurements_info_9` yielded nothing.
- Reordered the report so `result` (the plain-English verdict) is the very first key \u2014 it was getting cut off at the bottom of a long scrollable box on a phone screen.
- Added a "Copy JSON" button and a color-coded summary line to the diagnostics panel so the full trace can be copied in one tap.

## Next step
Please click **Run Diagnostics** again once this deploys and share the `perTableProbe` section \u2014 that'll show the raw response from Renpho for the actual measurement table and pinpoint the fix.

## Verified
- `npx tsc --noEmit` \u2014 clean
- `npx eslint` on changed files \u2014 clean
- `npx next build` \u2014 full production build succeeds
